### PR TITLE
feat: added enpoint /order/my-orders

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -34,6 +34,17 @@ class OrderController extends Controller
 
     }
 
+    public function getMyOrders(): \Illuminate\Http\JsonResponse|\Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    {
+        try {
+            $orders = $this->orderService->getOrdersByCurrentUser(10);
+
+            return LoadingOrderResource::collection($orders);
+        } catch (ModelNotFoundException $exception) {
+            return response()->json(['message' => 'No orders found for the current user'], 404);
+        }
+    }
+
     public function scheduleOrder(ScheduleOrderRequest $request): \Illuminate\Http\JsonResponse
     {
         try {

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -21,6 +21,18 @@ class OrderService
         return LoadingOrder::with('customer', 'destination', 'carrier', 'driver', 'vehicle', 'operator', 'dock', 'items.product', 'items.packages')->paginate($perPage);
     }
 
+    public function getOrdersByCurrentUser(string $perPage): LengthAwarePaginator
+    {
+        $authUser = auth()->user();
+
+        return LoadingOrder::with('customer', 'destination', 'carrier', 'driver', 'vehicle', 'operator', 'dock', 'items.product', 'items.packages')
+            ->where('created_by', $authUser->id)
+            ->orWhere('operator_id', $authUser->id)
+            //->where('status', '!=', 'pending')
+            ->orderBy('scheduled_at', 'desc')
+            ->paginate($perPage);
+    }
+
     /**
      * @throws \Exception
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/operators', [UserController::class, 'getOperators']);
 
+    Route::get('/order/my-orders', [OrderController::class, 'getMyOrders']);
     Route::get('/order/{orderId?}', [OrderController::class, 'getOrder']);
     Route::post('/order/schedule-order', [OrderController::class, 'scheduleOrder']);
 

--- a/tests/Feature/GetOrderTest.php
+++ b/tests/Feature/GetOrderTest.php
@@ -47,65 +47,11 @@ class GetOrderTest extends TestCase
 
         $token = $user->createToken('test-token')->plainTextToken;
 
-        $payload = [
-            'source_system' => 'SAP',
-            'loadingOrder' => [
-                'external_id' => '123456789',
-                'issue_date' => now()->format('Y-m-d'),
-                'status' => 'pending',
-
-                'customer' => [
-                    'external_id' => fake()->numerify('#########'),
-                    'name' => fake()->company(),
-                ],
-
-                'destination' => [
-                    'external_id' => fake()->numerify('#########'),
-                    'name' => fake()->company(),
-                    'address' => fake()->address(),
-                    'city' => fake()->city(),
-                    'state' => fake()->stateAbbr(),
-                    'postal_code' => fake()->numerify('########'),
-                ],
-
-                'carrier' => [
-                    'external_id' => fake()->numerify('#########'),
-                    'name' => fake()->company(),
-                ],
-
-                'vehicle' => [
-                    'external_id' => fake()->numerify('#########'),
-                    'vehiclePlate' => fake()->bothify('???-####'),
-                ],
-
-                'driver' => [
-                    'external_id' => fake()->numerify('#########'),
-                    'name' => fake()->name(),
-                ],
-
-                'items' => [
-                    [
-                        'product_sku' => fake()->bothify('PRD-###'),
-                        'product_description' => fake()->sentence(),
-                        'quantity' => 10,
-                        'unit' => 'pcs',
-                        'packages' => [
-                            [
-                                'unique_package_code' => fake()->numerify('#########'),
-                                'quantity_in_package' => 10,
-                            ]
-                        ],
-                    ],
-                ],
-            ]
-        ];
-
-        // Cria a ordem via integração
+        $payload = $this->buildOrderPayload('123456789');
         $creationResponse = $this->postJson('/api/integration/order', $payload, $this->getIntegrationHeaders());
         $creationResponse->assertStatus(202);
 
-        // Fetch the order from DB since response is async (202) and doesn't return ID directly
-        $order = \App\Models\LoadingOrder::where('external_id', '123456789')->firstOrFail();
+        $order = \App\Models\LoadingOrder::query()->where('external_id', '123456789')->firstOrFail();
         $orderId = $order->id;
 
         $response = $this->withHeaders([
@@ -154,54 +100,7 @@ class GetOrderTest extends TestCase
         $ordersCount = 3;
 
         for ($i = 0; $i < $ordersCount; $i++) {
-            $payload = [
-                'source_system' => 'SAP',
-                'loadingOrder' => [
-                    'external_id' => fake()->unique()->numerify('#########'),
-                    'issue_date' => now()->format('Y-m-d'),
-                    'status' => 'pending',
-
-                    'customer' => [
-                        'external_id' => fake()->numerify('#########'),
-                        'name' => fake()->company(),
-                    ],
-
-                    'destination' => [
-                        'external_id' => fake()->numerify('#########'),
-                        'name' => fake()->company(),
-                    ],
-
-                    'carrier' => [
-                        'external_id' => fake()->numerify('#########'),
-                        'name' => fake()->company(),
-                    ],
-
-                    'vehicle' => [
-                        'external_id' => fake()->numerify('#########'),
-                        'vehiclePlate' => fake()->bothify('???-####'),
-                    ],
-
-                    'driver' => [
-                        'external_id' => fake()->numerify('#########'),
-                        'name' => fake()->name(),
-                    ],
-
-                    'items' => [
-                        [
-                            'product_sku' => fake()->bothify('PRD-###'),
-                            'product_description' => fake()->sentence(),
-                            'quantity' => 5,
-                            'packages' => [
-                                [
-                                    'unique_package_code' => fake()->numerify('#########'),
-                                    'quantity_in_package' => 5,
-                                ]
-                            ],
-                        ],
-                    ],
-                ]
-            ];
-
+            $payload = $this->buildOrderPayload(fake()->unique()->numerify('#########'));
             $this->postJson('/api/integration/order', $payload, $this->getIntegrationHeaders())->assertStatus(202);
         }
 
@@ -232,8 +131,98 @@ class GetOrderTest extends TestCase
             ]);
     }
 
+    public function test_it_returns_only_orders_belonging_to_the_logged_in_user(): void
+    {
+        $loggedInUser = User::factory()->create([
+            'email' => 'operador_logado@email.com',
+            'password' => Hash::make('password'),
+            'rule' => 'operador',
+        ]);
+        $token = $loggedInUser->createToken('test-token')->plainTextToken;
+
+        $otherUser = User::factory()->create([
+            'email' => 'outro_operador@email.com',
+            'password' => Hash::make('password'),
+            'rule' => 'operador',
+        ]);
+
+        $aux = $this->postJson('/api/integration/order', $this->buildOrderPayload('MY-ORD-1'), $this->getIntegrationHeaders());
+        $this->postJson('/api/integration/order', $this->buildOrderPayload('MY-ORD-2'), $this->getIntegrationHeaders());
+        $this->postJson('/api/integration/order', $this->buildOrderPayload('OTHER-ORD-3'), $this->getIntegrationHeaders());
+
+        \App\Models\LoadingOrder::query()->where('external_id', 'MY-ORD-1')->update(['operator_id' => $loggedInUser->id]);
+        \App\Models\LoadingOrder::query()->where('external_id', 'MY-ORD-2')->update(['operator_id' => $loggedInUser->id]);
+        \App\Models\LoadingOrder::query()->where('external_id', 'OTHER-ORD-3')->update(['operator_id' => $otherUser->id]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->get('/api/order/my-orders');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2, 'data')
+            ->assertJsonFragment(['external_id' => 'MY-ORD-1'])
+            ->assertJsonFragment(['external_id' => 'MY-ORD-2'])
+            ->assertJsonMissing(['external_id' => 'OTHER-ORD-3']);
+    }
+
     private function getIntegrationHeaders(): array
     {
         return ['X-API-KEY' => config('services.integration.api_key')];
+    }
+
+    private function buildOrderPayload(string $externalId): array
+    {
+        return [
+            'source_system' => 'SAP',
+            'loadingOrder' => [
+                'external_id' => $externalId,
+                'issue_date' => now()->format('Y-m-d'),
+                'status' => 'pending',
+
+                'customer' => [
+                    'external_id' => fake()->numerify('#########'),
+                    'name' => fake()->company(),
+                ],
+
+                'destination' => [
+                    'external_id' => fake()->numerify('#########'),
+                    'name' => fake()->company(),
+                    'address' => fake()->address(),
+                    'city' => fake()->city(),
+                    'state' => fake()->stateAbbr(),
+                    'postal_code' => fake()->numerify('########'),
+                ],
+
+                'carrier' => [
+                    'external_id' => fake()->numerify('#########'),
+                    'name' => fake()->company(),
+                ],
+
+                'vehicle' => [
+                    'external_id' => fake()->numerify('#########'),
+                    'vehiclePlate' => fake()->bothify('???-####'),
+                ],
+
+                'driver' => [
+                    'external_id' => fake()->numerify('#########'),
+                    'name' => fake()->name(),
+                ],
+
+                'items' => [
+                    [
+                        'product_sku' => fake()->bothify('PRD-###'),
+                        'product_description' => fake()->sentence(),
+                        'quantity' => 10,
+                        'unit' => 'pcs',
+                        'packages' => [
+                            [
+                                'unique_package_code' => fake()->numerify('#########'),
+                                'quantity_in_package' => 10,
+                            ]
+                        ],
+                    ],
+                ],
+            ]
+        ];
     }
 }


### PR DESCRIPTION
This pull request introduces a new "My Orders" feature that allows authenticated users to retrieve only the orders associated with their account. It includes updates to the backend logic, API routes, and feature tests to support and validate this functionality. Additionally, the test code has been refactored for better maintainability and clarity.

**New "My Orders" endpoint and backend logic:**

* Added a new `getMyOrders` method to `OrderController` that returns orders for the currently authenticated user, using the new `getOrdersByCurrentUser` service method. [[1]](diffhunk://#diff-182b9a351384c5fe5f1aed11c69981dedc926786c45de8f72dbee0843e2fcd82R37-R47) [[2]](diffhunk://#diff-9b210f381714a9f4a978e93a238e68d8d645b71310c9c2b17ecb686e1ee1c533R24-R35)
* Introduced the `/api/order/my-orders` route to expose the new endpoint.

**Feature tests and test code improvements:**

* Added a new test to ensure the "My Orders" endpoint returns only orders belonging to the logged-in user, and refactored test code to use a `buildOrderPayload` helper for payload generation.
* Updated test payloads to include more complete address information and standardized item quantities and units for consistency. [[1]](diffhunk://#diff-1299d32ce7f6992088559e3f5112cc2fe08f24edaffe498d1a094d00c4d0ed33R190-R193) [[2]](diffhunk://#diff-1299d32ce7f6992088559e3f5112cc2fe08f24edaffe498d1a094d00c4d0ed33L193-L237)
* Refactored existing tests to use the new helper methods for payload creation and integration headers, improving code reuse and readability.