### PR TITLE
refactor: added finish justification order

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\LoadingOrderResource;
 use App\Services\OrderService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use OpenApi\Attributes as OA;
@@ -168,6 +169,14 @@ class OrderController extends Controller
         path: "/api/order/{orderId}/finish-order",
         summary: "Finaliza uma ordem de carregamento",
         security: [["bearerAuth" => []]],
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: "justification", description: "Justificativa ou observação", type: "string")
+                ]
+            )
+        ),
         tags: ["Orders"],
         parameters: [
             new OA\Parameter(
@@ -180,16 +189,17 @@ class OrderController extends Controller
         ],
         responses: [
             new OA\Response(response: 200, description: "Ordem finalizada com sucesso"),
-            new OA\Response(response: 400, description: "A ordem não está no status 'in_progress'"),
+            new OA\Response(response: 400, description: "A ordem não está em andamento ou falta justificativa"),
             new OA\Response(response: 403, description: "Você não tem permissão para finalizar esta ordem"),
             new OA\Response(response: 404, description: "Ordem de carregamento não encontrada"),
             new OA\Response(response: 500, description: "Erro interno no servidor")
         ]
     )]
-    public function finishOrder($orderId): \Illuminate\Http\JsonResponse
-    {
+    public function finishOrder(Request $request, $orderId): \Illuminate\Http\JsonResponse    {
         try {
-            $order = $this->orderService->finishOrder(auth()->user(), $orderId);
+            $justification = $request->input('justification');
+
+            $order = $this->orderService->finishOrder(auth()->user(), $orderId, $justification);
 
             return response()->json([
                 'success' => true,

--- a/app/Http/Resources/PackageResource.php
+++ b/app/Http/Resources/PackageResource.php
@@ -20,12 +20,9 @@ class PackageResource extends JsonResource
             'quantity_in_package' => $this->quantity_in_package,
             'status' => $this->checklistEntry ? 'checked' : 'unchecked',
 
-            // CORREÇÃO AQUI: Removido o ->name
             'checked_at' => $this->checklistEntry?->scanned_at,
 
-            // Aqui está correto, assumindo que scannedBy é a relação com o model User
             'checked_by' => $this->checklistEntry?->scannedBy?->name,
-
         ];
     }
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -71,15 +71,19 @@ class OrderService
             throw new BadRequestException('A ordem de carregamento deve estar no status "scheduled" para ser iniciada.');
         }
 
-        return $this->updateOrderAndRecordHistory($order, 'in_progress', $operator);
+        $updateData = [
+            'started_at' => now(),
+        ];
+
+        return $this->updateOrderAndRecordHistory($order, 'in_progress', $operator, $updateData);
     }
 
     /**
      * @throws AuthorizationException
      */
-    public function finishOrder(User $operator, string $orderId): LoadingOrder
+    public function finishOrder(User $operator, string $orderId, ?string $justification = null): LoadingOrder
     {
-        $order = LoadingOrder::query()->findOrFail($orderId);
+        $order = LoadingOrder::with('items.packages')->findOrFail($orderId);
 
         if ($order->operator_id !== $operator->id) {
             throw new AuthorizationException('Você não tem permissão para finalizar esta ordem.');
@@ -89,7 +93,25 @@ class OrderService
             throw new BadRequestException('A ordem de carregamento deve estar no status "in_progress" para ser finalizada.');
         }
 
-        return $this->updateOrderAndRecordHistory($order, 'completed', $operator);
+        $totalPackages = $order->items->flatMap->packages->count();
+        $checkedPackages = $order->items->flatMap->packages->where('status', 'checked')->count();
+        $isDivergent = $checkedPackages < $totalPackages;
+
+        if ($isDivergent && empty($justification)) {
+            throw new BadRequestException('A justificativa é obrigatória para finalizar uma carga incompleta.');
+        }
+
+        $updateData = [
+            'completed_at' => now(),
+        ];
+
+        $newStatus = $isDivergent ? 'divergence' : 'completed';
+
+        if (!empty($justification)) {
+            $updateData['justification'] = $justification;
+        }
+
+        return $this->updateOrderAndRecordHistory($order, $newStatus, $operator, $updateData);
     }
 
     private function updateOrderAndRecordHistory(LoadingOrder $order, string $newStatus, User $user, array $updateData = []): LoadingOrder


### PR DESCRIPTION
This pull request updates the order finalization flow to require a justification when completing an order with missing (unchecked) packages, improves OpenAPI documentation, and refines how order status and timestamps are managed. The main changes are grouped below:

**Order Completion Logic & Validation:**

* The `finishOrder` method in `OrderService` now requires a justification if not all packages are checked before allowing the order to be finalized. If justification is missing for incomplete orders, an error is thrown. The order status is set to `'divergence'` if there are unchecked packages, otherwise `'completed'`. Completion timestamps and justification are recorded as appropriate. (`[[1]](diffhunk://#diff-9b210f381714a9f4a978e93a238e68d8d645b71310c9c2b17ecb686e1ee1c533L74-R86)`, `[[2]](diffhunk://#diff-9b210f381714a9f4a978e93a238e68d8d645b71310c9c2b17ecb686e1ee1c533L92-R114)`)

**API & Request Handling:**

* The `finishOrder` controller method now accepts a `justification` field in the request body, and passes it to the service layer. The OpenAPI documentation for the endpoint is updated to reflect this optional field and clarify error responses. (`[[1]](diffhunk://#diff-182b9a351384c5fe5f1aed11c69981dedc926786c45de8f72dbee0843e2fcd82R10)`, `[[2]](diffhunk://#diff-182b9a351384c5fe5f1aed11c69981dedc926786c45de8f72dbee0843e2fcd82R172-R179)`, `[[3]](diffhunk://#diff-182b9a351384c5fe5f1aed11c69981dedc926786c45de8f72dbee0843e2fcd82L183-R202)`)

**Order Start Logic:**

* When starting an order, the `started_at` timestamp is now set and passed to the update logic, improving tracking of order progress. (`[app/Services/OrderService.phpL74-R86](diffhunk://#diff-9b210f381714a9f4a978e93a238e68d8d645b71310c9c2b17ecb686e1ee1c533L74-R86)`)

**Resource Output:**

* Minor cleanup in `PackageResource` to clarify how `checked_by` and `checked_at` are set, ensuring correct user and timestamp information is returned. (`[app/Http/Resources/PackageResource.phpL23-L28](diffhunk://#diff-a9d12260a44c36aab4d13d03af9a2c5458890c1bd5df5a753d7fa1310e98375aL23-L28)`)