### PR TITLE
feat: added list photo upload

### DIFF
--- a/app/Http/Controllers/OrderPhotoController.php
+++ b/app/Http/Controllers/OrderPhotoController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\OrderPhotoRequest;
+use App\Http\Resources\PhotoResource;
 use App\Services\OrderPhotoService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 
@@ -39,6 +41,29 @@ class OrderPhotoController extends Controller
         } catch (\Exception $e) {
             Log::error("Erro ao anexar foto: " . $e->getMessage());
             return response()->json(['message' => 'Erro interno ao anexar foto.'], 500);
+        }
+    }
+
+    public function index(Request $request, $orderId): \Illuminate\Http\JsonResponse
+    {
+        try {
+            $photos = $this->orderPhotoService->list(auth()->user(), $orderId);
+
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'loading_order_id' => $orderId,
+                    'count' => $photos->count(),
+                    'photos' => PhotoResource::collection($photos)->toArray($request),
+                ],
+            ]);
+        } catch (ModelNotFoundException $e) {
+            return response()->json(['message' => 'Ordem de carregamento não encontrada.'], 404);
+        } catch (AuthorizationException $e) {
+            return response()->json(['message' => $e->getMessage()], 403);
+        } catch (\Exception $e) {
+            Log::error("Erro ao listar fotos: " . $e->getMessage());
+            return response()->json(['message' => 'Erro interno ao listar fotos.'], 500);
         }
     }
 }

--- a/app/Http/Resources/PhotoResource.php
+++ b/app/Http/Resources/PhotoResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PhotoResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $url = null;
+        if (!empty($this->drive_id)) {
+            $template = config('services.google_drive.file_url', 'https://drive.google.com/uc?id={id}');
+            $url = str_replace('{id}', $this->drive_id, $template);
+        }
+
+        return [
+            'id' => $this->id,
+            'loading_order_id' => $this->loading_order_id,
+            'storage_path' => $this->storage_path,
+            'drive_id' => $this->drive_id,
+            'mime' => $this->mime,
+            'status' => $this->status,
+            'uploaded_by' => $this->uploaded_by,
+            'uploaded_at' => $this->uploaded_at,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'url' => $url,
+        ];
+    }
+}

--- a/app/Services/OrderPhotoService.php
+++ b/app/Services/OrderPhotoService.php
@@ -54,4 +54,22 @@ class OrderPhotoService
 
         return $photos;
     }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function list(User $operator, string $orderId): \Illuminate\Support\Collection
+    {
+        $order = LoadingOrder::query()->find($orderId);
+
+        if (!$order) {
+            throw new ModelNotFoundException('Ordem de carregamento não encontrada.');
+        }
+
+        if ($order->operator_id !== $operator->id) {
+            throw new AuthorizationException('Acesso negado.');
+        }
+
+        return $order->photos()->orderByDesc('created_at')->get();
+    }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Third Party Services
@@ -38,6 +37,10 @@ return [
     'integration' => [
         'api_key'    => env('INTEGRATION_API_KEY'),
         'rate_limit' => env('INTEGRATION_RATE_LIMIT', 60), // requests per minute per API Key
+    ],
+
+    'google_drive' => [
+        'file_url' => env('GOOGLE_DRIVE_FILE_URL', 'https://drive.google.com/uc?id={id}'),
     ],
 
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::post('/order/{orderId}/checklist', [CheckListEntryController::class, 'store']);
     Route::post('/order/{orderId}/photos', [OrderPhotoController::class, 'store']);
+    Route::get('/order/{orderId}/photos', [OrderPhotoController::class, 'index']);
 });
 
 Route::middleware(['integration.auth', 'throttle:integration'])->group(function () {

--- a/tests/Feature/OrderPhotoListTest.php
+++ b/tests/Feature/OrderPhotoListTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\LoadingOrder;
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderPhotoListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setupOrderEnvironment(string $externalId, string $status = 'scheduled', $operator = null): array
+    {
+        $user = $operator ?? User::factory()->create(['rule' => 'operador']);
+        $token = $user->createToken('test-token')->plainTextToken;
+
+        $this->postJson('/api/integration/order', $this->buildOrderPayload($externalId), [
+            'X-API-KEY' => config('services.integration.api_key')
+        ]);
+
+        $order = LoadingOrder::query()->where('external_id', $externalId)->first();
+        $order->update([
+            'status' => $status,
+            'operator_id' => $user->id
+        ]);
+
+        return [$user, $token, $order->fresh()];
+    }
+
+    public function test_it_lists_order_photos_for_operator(): void
+    {
+        [$user, $token, $order] = $this->setupOrderEnvironment('ORD-PHOTO-LIST-1', 'in_progress');
+
+        $firstPhoto = Photo::query()->create([
+            'loading_order_id' => $order->id,
+            'storage_path' => 'Cargas/' . $order->external_id . '/first.png',
+            'drive_id' => 'drive-first',
+            'mime' => 'image/png',
+            'status' => Photo::STATUS_UPLOADED,
+            'uploaded_by' => $user->id,
+            'uploaded_at' => now()->subMinute(),
+        ]);
+
+        $secondPhoto = Photo::query()->create([
+            'loading_order_id' => $order->id,
+            'storage_path' => 'Cargas/' . $order->external_id . '/second.jpg',
+            'drive_id' => 'drive-second',
+            'mime' => 'image/jpeg',
+            'status' => Photo::STATUS_PENDING,
+            'uploaded_by' => $user->id,
+            'uploaded_at' => now(),
+        ]);
+
+        $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
+            ->getJson("/api/order/{$order->id}/photos");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.count', 2)
+            ->assertJsonCount(2, 'data.photos')
+            ->assertJsonFragment(['id' => $firstPhoto->id])
+            ->assertJsonFragment(['id' => $secondPhoto->id])
+            ->assertJsonFragment(['url' => 'https://drive.google.com/uc?id=' . $firstPhoto->drive_id])
+            ->assertJsonFragment(['url' => 'https://drive.google.com/uc?id=' . $secondPhoto->drive_id]);
+    }
+
+    public function test_it_returns_empty_list_when_no_photos_exist(): void
+    {
+        [$user, $token, $order] = $this->setupOrderEnvironment('ORD-PHOTO-LIST-2', 'in_progress');
+
+        $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
+            ->getJson("/api/order/{$order->id}/photos");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.count', 0)
+            ->assertJsonCount(0, 'data.photos');
+    }
+
+    public function test_it_fails_to_list_photos_for_another_operator(): void
+    {
+        [$user, $token, $order] = $this->setupOrderEnvironment('ORD-PHOTO-LIST-3', 'in_progress');
+
+        $otherUser = User::factory()->create(['rule' => 'operador']);
+        $order->update(['operator_id' => $otherUser->id]);
+
+        $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
+            ->getJson("/api/order/{$order->id}/photos");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_it_fails_to_list_photos_for_missing_order(): void
+    {
+        $user = User::factory()->create(['rule' => 'operador']);
+        $token = $user->createToken('test-token')->plainTextToken;
+        $missingOrderId = '00000000-0000-0000-0000-000000000000';
+
+        $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
+            ->getJson("/api/order/{$missingOrderId}/photos");
+
+        $response->assertStatus(404)
+            ->assertJsonFragment(['message' => 'Ordem de carregamento não encontrada.']);
+    }
+
+    private function buildOrderPayload(string $externalId): array
+    {
+        return [
+            'source_system' => 'SAP',
+            'loadingOrder' => [
+                'external_id' => $externalId,
+                'issue_date' => now()->format('Y-m-d'),
+                'status' => 'pending',
+                'customer' => ['external_id' => 'C1', 'name' => 'Test'],
+                'destination' => [
+                    'external_id' => 'D1', 'name' => 'Test', 'address' => 'X',
+                    'city' => 'X', 'state' => 'ST', 'postal_code' => '12345678'
+                ],
+                'carrier' => ['external_id' => 'T1', 'name' => 'Test'],
+                'vehicle' => ['external_id' => 'V1', 'vehiclePlate' => 'ABC1234'],
+                'driver' => ['external_id' => 'DR1', 'name' => 'Test'],
+                'items' => [[
+                    'product_sku' => 'SKU1', 'product_description' => 'Desc', 'quantity' => 1, 'unit' => 'UN',
+                    'packages' => [['unique_package_code' => 'PKG-' . $externalId, 'quantity_in_package' => 1]]
+                ]],
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
This pull request adds a new endpoint to list photos attached to a loading order, including authorization and error handling, and introduces a resource class for formatting photo data. It also provides configuration for Google Drive file URLs and comprehensive feature tests for the new functionality.

**API Enhancements**
* Added a new `index` method to `OrderPhotoController` that allows operators to list all photos attached to a specific loading order, with proper authorization and error handling. The response uses the new `PhotoResource` for consistent formatting.
* Registered the new GET route `/order/{orderId}/photos` in `routes/api.php` for listing order photos.

**Service Layer Updates**
* Implemented `list` method in `OrderPhotoService` to fetch and authorize access to photos for a given order, throwing exceptions for missing orders or unauthorized access.

**Resource & Configuration**
* Introduced `PhotoResource` to transform photo model data, including generating a Google Drive URL using a configurable template.
* Added `google_drive.file_url` configuration to `config/services.php` for customizable file URL templates.

**Testing**
* Added `OrderPhotoListTest` feature test covering successful listing, empty results, unauthorized access, and missing order scenarios for the new endpoint.