### PR TITLE
Fix/copilot review fixes

### DIFF
--- a/app/Enums/HttpStatus.php
+++ b/app/Enums/HttpStatus.php
@@ -10,7 +10,7 @@ enum HttpStatus: int
     case UNAUTHORIZED = 401;
     case FORBIDDEN = 403;
     case NOT_FOUND = 404;
-    case UMSUPPORTED_MEDIA_TYPE = 415;
+    case UNSUPPORTED_MEDIA_TYPE = 415;
     case UNPROCESSABLE_ENTITY = 422;
     case INTERNAL_SERVER_ERROR = 500;
 }

--- a/app/Http/Controllers/CheckListEntryController.php
+++ b/app/Http/Controllers/CheckListEntryController.php
@@ -61,6 +61,11 @@ class CheckListEntryController extends Controller
                 'message' => 'Pacote conferido com sucesso',
                 'data' => $checklistEntry,
             ], 200);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Ordem de carregamento não encontrada.',
+            ], 404);
         } catch (\Exception $e) {
             return response()->json([
                 'success' => false,

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -13,6 +13,17 @@ use OpenApi\Attributes as OA;
     url: "http://localhost",
     description: "Servidor API Local"
 )]
+#[OA\SecurityScheme(
+    securityScheme: "bearerAuth",
+    type: "http",
+    scheme: "bearer"
+)]
+#[OA\SecurityScheme(
+    securityScheme: "ApiKeyAuth",
+    type: "apiKey",
+    in: "header",
+    name: "X-API-KEY"
+)]
 abstract class Controller
 {
 }

--- a/app/Http/Controllers/Integration/DockController.php
+++ b/app/Http/Controllers/Integration/DockController.php
@@ -12,9 +12,9 @@ use OpenApi\Attributes as OA;
 class DockController extends Controller
 {
     #[OA\Post(
-        path: "/api/integration/docks",
+        path: "/api/integration/dock",
         summary: "Recebe e enfileira o payload de integração de docas",
-        security: [["bearerAuth" => []]],
+        security: [["ApiKeyAuth" => []]],
         requestBody: new OA\RequestBody(
             required: true,
             content: new OA\JsonContent(

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -78,7 +78,7 @@ class OrderController extends Controller
     }
 
     #[OA\Post(
-        path: "/api/order/schedule",
+        path: "/api/order/schedule-order",
         summary: "Agenda uma ordem de carregamento",
         security: [["bearerAuth" => []]],
         requestBody: new OA\RequestBody(

--- a/app/Http/Middleware/IntegrationAuth.php
+++ b/app/Http/Middleware/IntegrationAuth.php
@@ -17,11 +17,14 @@ class IntegrationAuth
     {
         $apiKey = $request->header('X-API-KEY');
 
-        if ($apiKey !== config('services.integration.api_key')) {
+        $expectedKey = config('services.integration.api_key');
+
+        if (empty($expectedKey) || $apiKey !== $expectedKey) {
             return response()->json([
                 'success' => false,
                 'message' => 'Unauthorized. Invalid or missing API token.',
-            ], 401);        }
+            ], 401);
+        }
 
         return $next($request);
     }

--- a/app/Http/Requests/ScheduleOrderRequest.php
+++ b/app/Http/Requests/ScheduleOrderRequest.php
@@ -25,8 +25,8 @@ class ScheduleOrderRequest extends FormRequest
             'id' => 'required|string',
             'scheduled_at' => 'required|date',
             'status' => 'required|string',
-            'dock_id' => 'nullable|integer',
-            'operator_id' => 'required|string',
+            'dock_id' => 'nullable|string',
+            'operator_id' => 'nullable|string',
         ];
     }
 
@@ -39,8 +39,7 @@ class ScheduleOrderRequest extends FormRequest
             'scheduled_at.date' => 'The scheduled_at field must be a valid date.',
             'status.required' => 'The status field is required.',
             'status.string' => 'The status field must be a string.',
-            'dock_id.integer' => 'The dock_id field must be an integer.',
-            'operator_id.required' => 'The operator_id field is required.',
+            'dock_id.string' => 'The dock_id field must be a string.',
             'operator_id.string' => 'The operator_id field must be a string.',
         ];
     }

--- a/app/Http/Resources/LoadingOrderResource.php
+++ b/app/Http/Resources/LoadingOrderResource.php
@@ -25,7 +25,7 @@ class LoadingOrderResource extends JsonResource
             'driver' => $this->driver?->name,
             'vehicle' => $this->vehicle?->vehiclePlate,
             'operator' => $this->operator?->name,
-            'dock' => $this->dock?->name,
+            'dock' => $this->dock?->dock_code,
             'justification' => $this->justification,
             'observations' => $this->observations,
             'scheduled_at' => $this->scheduled_at,

--- a/app/Jobs/ProcessDockJob.php
+++ b/app/Jobs/ProcessDockJob.php
@@ -5,13 +5,16 @@ namespace App\Jobs;
 use App\Exceptions\IntegrationException;
 use App\Services\DockService;
 use App\Services\IntegrationLogService;
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
 class ProcessDockJob implements ShouldQueue
 {
-    use Queueable;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
      * Número máximo de tentativas antes de considerar o job como falho.
@@ -69,7 +72,7 @@ class ProcessDockJob implements ShouldQueue
 
     public function failed(\Throwable $exception): void
     {
-        Log::error('Failed to process user integration', [
+        Log::error('Failed to process dock integration', [
             'payload' => $this->payload,
             'error' => $exception->getMessage(),
             'trace' => $exception->getTraceAsString(),
@@ -86,7 +89,7 @@ class ProcessDockJob implements ShouldQueue
 
         } catch (\Throwable $e) {
 
-            Log::error('Failed to log user integration error', [
+            Log::error('Failed to log dock integration error', [
                 'error' => $e->getMessage()
             ]);
         }

--- a/app/Jobs/UploadPhotoToDriveJob.php
+++ b/app/Jobs/UploadPhotoToDriveJob.php
@@ -36,6 +36,12 @@ class UploadPhotoToDriveJob implements ShouldQueue
                 'local_path' => $this->localPath,
             ]);
 
+            if ($photo) {
+                $photo->update([
+                    'status' => Photo::STATUS_FAILED,
+                ]);
+            }
+
             return;
         }
 

--- a/app/Models/Carrier.php
+++ b/app/Models/Carrier.php
@@ -13,8 +13,10 @@ class Carrier extends Model
     protected $table = 'carriers';
     protected $fillable = [
         'id',
+        'external_id',
+        'source_system',
         'name',
-        'tax_id',
+        'document',
         'contact_phone',
     ];
 

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -13,8 +13,11 @@ class Customer extends Model
     protected $table = 'customers';
     protected $fillable = [
         'id',
+        'external_id',
+        'source_system',
         'name',
-        'tax_id',
-        'address',
+        'document',
+        'email',
+        'phone',
     ];
 }

--- a/app/Models/Destination.php
+++ b/app/Models/Destination.php
@@ -13,7 +13,12 @@ class Destination extends Model
     protected $table = 'destinations';
     protected $fillable = [
         'id',
+        'external_id',
+        'source_system',
         'name',
-        'adress',
+        'address',
+        'postal_code',
+        'city',
+        'state',
     ];
 }

--- a/app/Models/LoadingOrder.php
+++ b/app/Models/LoadingOrder.php
@@ -78,9 +78,9 @@ class LoadingOrder extends Model
         return $this->hasMany(OrderItem::class);
     }
 
-    public function packages(): \Illuminate\Database\Eloquent\Relations\HasMany
+    public function packages(): \Illuminate\Database\Eloquent\Relations\HasManyThrough
     {
-        return $this->hasMany(Package::class);
+        return $this->hasManyThrough(Package::class, OrderItem::class);
     }
 
     public function photos(): \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Services/CheckListEntryService.php
+++ b/app/Services/CheckListEntryService.php
@@ -14,10 +14,13 @@ class CheckListEntryService
 {
     public function store(User $operator, $orderId, string $scannedCode)
     {
-        $order = LoadingOrder::query()
-            ->where('id', $orderId)
-            ->where('operator_id', $operator->id)
-            ->first();
+        $query = LoadingOrder::query()->where('id', $orderId);
+        
+        if ($operator->rule !== 'admin') {
+            $query->where('operator_id', $operator->id);
+        }
+
+        $order = $query->first();
 
         if (!$order) {
             $this->logScan($orderId, $operator->id, $scannedCode, null, 'error', 'Ordem de carregamento não encontrada.');

--- a/app/Services/EntityService.php
+++ b/app/Services/EntityService.php
@@ -18,7 +18,6 @@ class EntityService
     {
         if (!empty($data['external_id'])) {
             $customer = Customer::query()->where('external_id', $data['external_id'])
-                ->where('source_system', $data['source_system'] ?? null)
                 ->first();
 
             if ($customer) {
@@ -61,7 +60,6 @@ class EntityService
     {
         if (!empty($data['external_id'])) {
             $destination = Destination::query()->where('external_id', $data['external_id'])
-                ->where('source_system', $data['source_system'] ?? null)
                 ->first();
 
             if ($destination) {
@@ -106,7 +104,6 @@ class EntityService
     {
         if (!empty($data['external_id'])) {
             $carrier = Carrier::query()->where('external_id', $data['external_id'])
-                ->where('source_system', $data['source_system'] ?? null)
                 ->first();
 
             if ($carrier) {
@@ -146,7 +143,6 @@ class EntityService
     {
         if (!empty($data['external_id'])) {
             $vehicle = Vehicle::query()->where('external_id', $data['external_id'])
-                ->where('source_system', $data['source_system'] ?? null)
                 ->first();
 
             if ($vehicle) {
@@ -187,7 +183,6 @@ class EntityService
     {
         if (!empty($data['external_id'])) {
             $driver = Driver::query()->where('external_id', $data['external_id'])
-                ->where('source_system', $data['source_system'] ?? null)
                 ->first();
 
             if ($driver) {
@@ -277,7 +272,7 @@ class EntityService
     public function findOrCreateDock(array $data): Dock
     {
         $dock = Dock::query()->where('external_id', $data['external_id'])
-            ->where('source_system', $data['source_system'])->first();
+            ->first();
 
         if ($dock) {
             $dock->update([

--- a/app/Services/OrderPhotoService.php
+++ b/app/Services/OrderPhotoService.php
@@ -25,7 +25,7 @@ class OrderPhotoService
             throw new ModelNotFoundException('Ordem de carregamento não encontrada.');
         }
 
-        if ($order->operator_id !== $operator->id) {
+        if ($order->operator_id !== $operator->id && $operator->rule !== 'admin') {
             throw new AuthorizationException('Acesso negado.');
         }
 
@@ -66,7 +66,7 @@ class OrderPhotoService
             throw new ModelNotFoundException('Ordem de carregamento não encontrada.');
         }
 
-        if ($order->operator_id !== $operator->id) {
+        if ($order->operator_id !== $operator->id && $operator->rule !== 'admin') {
             throw new AuthorizationException('Acesso negado.');
         }
 

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -63,7 +63,7 @@ class OrderService
     {
         $order = LoadingOrder::query()->findOrFail($orderId);
 
-        if ($order->operator_id !== $operator->id) {
+        if ($order->operator_id !== $operator->id && $operator->rule !== 'admin') {
             throw new AuthorizationException('Você não tem permissão para iniciar esta ordem.');
         }
 
@@ -83,9 +83,9 @@ class OrderService
      */
     public function finishOrder(User $operator, string $orderId, ?string $justification = null): LoadingOrder
     {
-        $order = LoadingOrder::with('items.packages')->findOrFail($orderId);
+        $order = LoadingOrder::with('items.packages.checklistEntry')->findOrFail($orderId);
 
-        if ($order->operator_id !== $operator->id) {
+        if ($order->operator_id !== $operator->id && $operator->rule !== 'admin') {
             throw new AuthorizationException('Você não tem permissão para finalizar esta ordem.');
         }
 
@@ -94,7 +94,7 @@ class OrderService
         }
 
         $totalPackages = $order->items->flatMap->packages->count();
-        $checkedPackages = $order->items->flatMap->packages->where('status', 'checked')->count();
+        $checkedPackages = $order->items->flatMap->packages->filter(fn ($package) => $package->checklistEntry !== null)->count();
         $isDivergent = $checkedPackages < $totalPackages;
 
         if ($isDivergent && empty($justification)) {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,11 +17,13 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Gabriel Test',
-            'email' => 'admin@expedisoft.com',
-            'password' => bcrypt('senha123'),
-            'rule' => 'admin',
-        ]);
+        if (app()->environment('local')) {
+            User::factory()->create([
+                'name' => 'Gabriel Test',
+                'email' => 'admin@expedisoft.com',
+                'password' => bcrypt('senha123'),
+                'rule' => 'admin',
+            ]);
+        }
     }
 }

--- a/exemplo_payload_completo.json
+++ b/exemplo_payload_completo.json
@@ -3,9 +3,7 @@
   "loadingOrder": {
     "external_id": "ORD-2026-001",
     "issue_date": "2026-02-09",
-    //"delivery_date": "2026-02-15",
     "status": "pending",
-    //"total_value": 15000.00,
     "notes": "Entrega urgente - Cliente VIP",
 
     "customer": {
@@ -37,7 +35,6 @@
       "external_id": "VEH-789",
       "vehiclePlate": "ABC-1D23",
       "model": "Mercedes-Benz Axor 2544"
-      //"type": "Truck"
     },
 
     "driver": {

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,7 +22,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/operators', [UserController::class, 'getOperators']);
 
-    route::get('/docks', [DockController::class, 'getAllDocks']);
+    Route::get('/docks', [DockController::class, 'getAllDocks']);
 
     Route::get('/order/my-orders', [OrderController::class, 'getMyOrders']);
     Route::get('/order/{orderId?}', [OrderController::class, 'getOrder']);

--- a/tests/Feature/LoadOrderTest.php
+++ b/tests/Feature/LoadOrderTest.php
@@ -71,8 +71,12 @@ class LoadOrderTest extends TestCase
     {
         [$user, $token, $order] = $this->setupOrderEnvironment('ORD-FINISH-1', 'in_progress');
 
-        // Opcional: Você pode precisar simular que todos os pacotes foram escaneados
-        // dependendo da sua regra de negócio para permitir finalizar a ordem.
+        // Simulate scanning all packages
+        $package = $order->items()->first()->packages()->first();
+        $this->withHeaders(['Authorization' => 'Bearer ' . $token])
+            ->postJson("/api/order/{$order->id}/checklist", [
+                'qr_code' => $package->unique_package_code,
+            ]);
 
         $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
             ->postJson("/api/order/{$order->id}/finish-order");


### PR DESCRIPTION
This pull request introduces several improvements and corrections across the codebase, focusing on enhancing authorization logic, updating API documentation and validation, improving model relationships, and fixing minor bugs. The most significant changes involve relaxing operator restrictions for admin users, refining validation and model fields, and updating API security schemes and endpoints.

**Authorization and Access Control Improvements:**

* Updated authorization checks in `OrderPhotoService`, `OrderService`, and `CheckListEntryService` to allow admin users (with `rule === 'admin'`) to access or modify orders regardless of operator assignment. This change centralizes and simplifies admin permissions throughout the service layer. [[1]](diffhunk://#diff-d39589c90983e8dfab625fb0b5d0a9d5f460cc50a737c96f45d4f5017ba9b23fL28-R28) [[2]](diffhunk://#diff-d39589c90983e8dfab625fb0b5d0a9d5f460cc50a737c96f45d4f5017ba9b23fL69-R69) [[3]](diffhunk://#diff-9b210f381714a9f4a978e93a238e68d8d645b71310c9c2b17ecb686e1ee1c533L66-R66) [[4]](diffhunk://#diff-9b210f381714a9f4a978e93a238e68d8d645b71310c9c2b17ecb686e1ee1c533L86-R88) [[5]](diffhunk://#diff-a86e61dda3392a96e25f7bf70af923d70ab5ac7d7c9c6b39a3cd198592bb34e6L17-R23)
* In `CheckListEntryService`, only restricts order queries by `operator_id` for non-admin users, enabling admins to access any order.

**Validation, Model, and Resource Updates:**

* Adjusted validation rules in `ScheduleOrderRequest`: `dock_id` is now a nullable string instead of integer, and `operator_id` is now nullable. Corresponding validation messages were also updated. [[1]](diffhunk://#diff-1f5c01daf287eb6b68903233f60f9ad37c4352e50ddcddec43437398a41c6171L28-R29) [[2]](diffhunk://#diff-1f5c01daf287eb6b68903233f60f9ad37c4352e50ddcddec43437398a41c6171L42-R42)
* Updated `Carrier`, `Customer`, and `Destination` models to add new fields (`external_id`, `source_system`, etc.), renamed fields for clarity, and added additional contact information fields. [[1]](diffhunk://#diff-6858eb355dd192a2e58212428e9b1dd9b01e1e1aad4863a8547d65edfab7af18R16-R19) [[2]](diffhunk://#diff-94c180aed48d020bc2f192badaeeecefcdfe4d74baf5c7291353de19d9b66ac6R16-R21) [[3]](diffhunk://#diff-eae2e64a3257099f1876ad73846e40d25288181693d6c4e04b33ca5ff4ca707fR16-R22)
* In `LoadingOrder`, changed the `packages()` relationship from `hasMany` to `hasManyThrough`, allowing retrieval of packages via order items.
* Changed the `dock` field in `LoadingOrderResource` to use `dock_code` instead of `name`.

**API Documentation and Endpoint Adjustments:**

* Added OpenAPI security schemes for `bearerAuth` and `ApiKeyAuth` in the base controller, and updated the `DockController` endpoint to use `ApiKeyAuth` and a singular path (`/api/integration/dock`). [[1]](diffhunk://#diff-6eba513804f3952156d999eea3fb21199659f395d0092da71a10868b72bf59ceR16-R26) [[2]](diffhunk://#diff-0c580dea812754295fe4a579085c1bd3dfd6e685333d082dd3fb81cefd06fbcbL15-R17)
* Renamed the scheduling endpoint from `/api/order/schedule` to `/api/order/schedule-order` for clarity.

**Bug Fixes and Error Handling:**

* Fixed typo in the `HttpStatus` enum (`UMSUPPORTED_MEDIA_TYPE` → `UNSUPPORTED_MEDIA_TYPE`).
* Improved error handling in `CheckListEntryController` to return a 404 response when an order is not found.
* Enhanced API key middleware to handle missing or empty keys robustly.
* Updated `ProcessDockJob` to use the correct Laravel job traits and improved error log messages for clarity. [[1]](diffhunk://#diff-b2b717be2088b1d608399ee8c5b6c4539e3442aae90466b540c6db53f737f91dR8-R17) [[2]](diffhunk://#diff-b2b717be2088b1d608399ee8c5b6c4539e3442aae90466b540c6db53f737f91dL72-R75) [[3]](diffhunk://#diff-b2b717be2088b1d608399ee8c5b6c4539e3442aae90466b540c6db53f737f91dL89-R92)
* Ensured failed photo uploads update the photo status to `STATUS_FAILED`.

**Miscellaneous and Maintenance:**

* Removed unnecessary `source_system` checks in entity service methods to simplify lookups. [[1]](diffhunk://#diff-b65c6bd3c653aead3871cfeacbfc62e3becf8cac60e54a20df42f54b9c9c01f8L21) [[2]](diffhunk://#diff-b65c6bd3c653aead3871cfeacbfc62e3becf8cac60e54a20df42f54b9c9c01f8L64) [[3]](diffhunk://#diff-b65c6bd3c653aead3871cfeacbfc62e3becf8cac60e54a20df42f54b9c9c01f8L109) [[4]](diffhunk://#diff-b65c6bd3c653aead3871cfeacbfc62e3becf8cac60e54a20df42f54b9c9c01f8L149) [[5]](diffhunk://#diff-b65c6bd3c653aead3871cfeacbfc62e3becf8cac60e54a20df42f54b9c9c01f8L190) [[6]](diffhunk://#diff-b65c6bd3c653aead3871cfeacbfc62e3becf8cac60e54a20df42f54b9c9c01f8L280-R275)
* Added conditional seeding for local environments in the database seeder. [[1]](diffhunk://#diff-ccad8b4ee6013765c2bc672aa0515f8e99e42949c914cce01e0cb2b4e882775dR20) [[2]](diffhunk://#diff-ccad8b4ee6013765c2bc672aa0515f8e99e42949c914cce01e0cb2b4e882775dR29)
* Minor cleanup in example payloads and comments. [[1]](diffhunk://#diff-cad342326f11f749448757a01ee2ca02551e5f1e5cf6c0ca99388cebccf4e59dL6-L8) [[2]](diffhunk://#diff-cad342326f11f749448757a01ee2ca02551e5f1e5cf6c0ca99388cebccf4e59dL40)