### PR TITLE
Implement DTO layer for services and controllers with tests

### DIFF
--- a/app/DTOs/Entity/CarrierDTO.php
+++ b/app/DTOs/Entity/CarrierDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class CarrierDTO
+{
+    public function __construct(
+        public string  $externalId,
+        public string  $name,
+        public ?string $sourceSystem = null,
+        public ?string $document = null,
+        public ?string $contactPhone = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            externalId: $data['external_id'],
+            name: $data['name'],
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+            document: $data['document'] ?? null,
+            contactPhone: $data['phone'] ?? $data['contact_phone'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'name'          => $this->name,
+            'document'      => $this->document,
+            'contact_phone' => $this->contactPhone,
+        ];
+    }
+}

--- a/app/DTOs/Entity/CustomerDTO.php
+++ b/app/DTOs/Entity/CustomerDTO.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class CustomerDTO
+{
+    public function __construct(
+        public string  $externalId,
+        public string  $name,
+        public ?string $sourceSystem = null,
+        public ?string $document = null,
+        public ?string $email = null,
+        public ?string $phone = null,
+        public ?string $address = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            externalId: $data['external_id'],
+            name: $data['name'],
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+            document: $data['document'] ?? null,
+            email: $data['email'] ?? null,
+            phone: $data['phone'] ?? null,
+            address: $data['address'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'name'          => $this->name,
+            'document'      => $this->document,
+            'email'         => $this->email,
+            'phone'         => $this->phone,
+            'address'       => $this->address,
+        ];
+    }
+}

--- a/app/DTOs/Entity/DestinationDTO.php
+++ b/app/DTOs/Entity/DestinationDTO.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class DestinationDTO
+{
+    public function __construct(
+        public string  $externalId,
+        public string  $name,
+        public ?string $sourceSystem = null,
+        public ?string $address = null,
+        public ?string $city = null,
+        public ?string $state = null,
+        public ?string $postalCode = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            externalId: $data['external_id'],
+            name: $data['name'],
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+            address: $data['address'] ?? null,
+            city: $data['city'] ?? null,
+            state: $data['state'] ?? null,
+            postalCode: $data['postal_code'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'name'          => $this->name,
+            'address'       => $this->address,
+            'city'          => $this->city,
+            'state'         => $this->state,
+            'postal_code'   => $this->postalCode,
+        ];
+    }
+}

--- a/app/DTOs/Entity/DockDTO.php
+++ b/app/DTOs/Entity/DockDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class DockDTO
+{
+    public function __construct(
+        public string  $externalId,
+        public string  $dockCode,
+        public ?string $sourceSystem = null,
+        public ?string $description = null,
+        public ?string $location = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            externalId: $data['external_id'],
+            dockCode: $data['dock_code'],
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+            description: $data['description'] ?? null,
+            location: $data['location'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'dock_code'     => $this->dockCode,
+            'description'   => $this->description,
+            'location'      => $this->location,
+        ];
+    }
+}

--- a/app/DTOs/Entity/DriverDTO.php
+++ b/app/DTOs/Entity/DriverDTO.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class DriverDTO
+{
+    public function __construct(
+        public string  $name,
+        public string  $carrierId,
+        public ?string $externalId = null,
+        public ?string $sourceSystem = null,
+        public ?string $document = null,
+        public ?string $phone = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            name: $data['name'],
+            carrierId: $data['carrier_id'],
+            externalId: $data['external_id'] ?? null,
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+            document: $data['document'] ?? null,
+            phone: $data['phone'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'name'          => $this->name,
+            'document'      => $this->document,
+            'phone'         => $this->phone,
+            'carrier_id'    => $this->carrierId,
+        ];
+    }
+}

--- a/app/DTOs/Entity/ProductDTO.php
+++ b/app/DTOs/Entity/ProductDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class ProductDTO
+{
+    public function __construct(
+        public string  $sku,
+        public string  $description,
+        public ?string $unit = 'un',
+        public ?float  $weight = null,
+        public ?string $barcode = null,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            sku: $data['product_sku'],
+            description: $data['description'] ?? $data['product_description'],
+            unit: $data['unit'] ?? 'un',
+            weight: $data['weight'] ?? null,
+            barcode: $data['barcode'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'product_sku' => $this->sku,
+            'description' => $this->description,
+            'unit'        => $this->unit,
+            'weight'      => $this->weight,
+            'barcode'     => $this->barcode,
+        ];
+    }
+}

--- a/app/DTOs/Entity/UserDTO.php
+++ b/app/DTOs/Entity/UserDTO.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class UserDTO
+{
+    public function __construct(
+        public string  $name,
+        public string  $email,
+        public ?string $externalId = null,
+        public ?string $sourceSystem = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            name: $data['name'],
+            email: $data['email'],
+            externalId: $data['external_id'] ?? null,
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'name'          => $this->name,
+            'email'         => $this->email,
+        ];
+    }
+}

--- a/app/DTOs/Entity/VehicleDTO.php
+++ b/app/DTOs/Entity/VehicleDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\DTOs\Entity;
+
+readonly class VehicleDTO
+{
+    public function __construct(
+        public string  $vehiclePlate,
+        public string  $carrierId,
+        public ?string $externalId = null,
+        public ?string $sourceSystem = null,
+        public ?string $model = null,
+    ) {
+    }
+
+    public static function fromArray(array $data, ?string $sourceSystem = null): self
+    {
+        return new self(
+            vehiclePlate: $data['vehiclePlate'],
+            carrierId: $data['carrier_id'],
+            externalId: $data['external_id'] ?? null,
+            sourceSystem: $data['source_system'] ?? $sourceSystem,
+            model: $data['model'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'external_id'   => $this->externalId,
+            'source_system' => $this->sourceSystem,
+            'vehiclePlate'  => $this->vehiclePlate,
+            'model'         => $this->model,
+            'carrier_id'    => $this->carrierId,
+        ];
+    }
+}

--- a/app/DTOs/Integration/DockIntegrationDTO.php
+++ b/app/DTOs/Integration/DockIntegrationDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DTOs\Integration;
+
+use App\DTOs\Entity\DockDTO;
+
+readonly class DockIntegrationDTO
+{
+    public function __construct(
+        public string  $sourceSystem,
+        public DockDTO $dock,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            sourceSystem: $data['source_system'],
+            dock: DockDTO::fromArray($data['dock'], $data['source_system']),
+        );
+    }
+}

--- a/app/DTOs/Integration/LoadingOrderIntegrationDTO.php
+++ b/app/DTOs/Integration/LoadingOrderIntegrationDTO.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\DTOs\Integration;
+
+use App\DTOs\Entity\CarrierDTO;
+use App\DTOs\Entity\CustomerDTO;
+use App\DTOs\Entity\DestinationDTO;
+use App\DTOs\Entity\DriverDTO;
+use App\DTOs\Entity\VehicleDTO;
+
+readonly class LoadingOrderIntegrationDTO
+{
+    /**
+     * @param OrderItemIntegrationDTO[] $items
+     */
+    public function __construct(
+        public string         $sourceSystem,
+        public string         $externalId,
+        public string         $issueDate,
+        public string         $status,
+        public CustomerDTO    $customer,
+        public DestinationDTO $destination,
+        public CarrierDTO     $carrier,
+        public VehicleDTO     $vehicle,
+        public DriverDTO      $driver,
+        public array          $items,
+        public ?string        $deliveryDate = null,
+        public ?string        $notes = null,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        $sourceSystem = $data['source_system'];
+        $orderData    = $data['loadingOrder'];
+
+        $carrier = CarrierDTO::fromArray($orderData['carrier'], $sourceSystem);
+
+        $vehicle = new VehicleDTO(
+            vehiclePlate: $orderData['vehicle']['vehiclePlate'],
+            carrierId: '',        // preenchido pelo service após persistência da carrier
+            externalId: $orderData['vehicle']['external_id'] ?? null,
+            sourceSystem: $sourceSystem,
+            model: $orderData['vehicle']['model'] ?? null,
+        );
+
+        $driver = new DriverDTO(
+            name: $orderData['driver']['name'],
+            carrierId: '',        // preenchido pelo service após persistência da carrier
+            externalId: $orderData['driver']['external_id'] ?? null,
+            sourceSystem: $sourceSystem,
+            document: $orderData['driver']['document'] ?? null,
+            phone: $orderData['driver']['phone'] ?? null,
+        );
+
+        $items = array_map(
+            fn (array $item) => OrderItemIntegrationDTO::fromArray($item),
+            $orderData['items']
+        );
+
+        return new self(
+            sourceSystem: $sourceSystem,
+            externalId: $orderData['external_id'],
+            issueDate: $orderData['issue_date'],
+            status: $orderData['status'] ?? 'pending',
+            customer: CustomerDTO::fromArray($orderData['customer'], $sourceSystem),
+            destination: DestinationDTO::fromArray($orderData['destination'], $sourceSystem),
+            carrier: $carrier,
+            vehicle: $vehicle,
+            driver: $driver,
+            items: $items,
+            deliveryDate: $orderData['delivery_date'] ?? null,
+            notes: $orderData['notes'] ?? null,
+        );
+    }
+}

--- a/app/DTOs/Integration/OrderItemIntegrationDTO.php
+++ b/app/DTOs/Integration/OrderItemIntegrationDTO.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\DTOs\Integration;
+
+use App\DTOs\Entity\ProductDTO;
+
+readonly class OrderItemIntegrationDTO
+{
+    /**
+     * @param PackageIntegrationDTO[] $packages
+     */
+    public function __construct(
+        public ProductDTO $product,
+        public int        $quantity,
+        public array      $packages = [],
+    ) {
+    }
+
+    public static function fromArray(array $item): self
+    {
+        $packages = array_map(
+            fn (array $package) => PackageIntegrationDTO::fromArray($package),
+            $item['packages'] ?? []
+        );
+
+        return new self(
+            product: ProductDTO::fromArray([
+                'product_sku'         => $item['product_sku'],
+                'description'         => $item['product_description'],
+                'unit'                => $item['unit'] ?? 'un',
+                'weight'              => $item['weight'] ?? null,
+                'barcode'             => $item['barcode'] ?? null,
+            ]),
+            quantity: $item['quantity'],
+            packages: $packages,
+        );
+    }
+}

--- a/app/DTOs/Integration/PackageIntegrationDTO.php
+++ b/app/DTOs/Integration/PackageIntegrationDTO.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\DTOs\Integration;
+
+readonly class PackageIntegrationDTO
+{
+    public function __construct(
+        public string $uniquePackageCode,
+        public int    $quantityInPackage = 1,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            uniquePackageCode: $data['unique_package_code'],
+            quantityInPackage: $data['quantity_in_package'] ?? 1,
+        );
+    }
+}

--- a/app/DTOs/Integration/UserIntegrationDTO.php
+++ b/app/DTOs/Integration/UserIntegrationDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DTOs\Integration;
+
+use App\DTOs\Entity\UserDTO;
+
+readonly class UserIntegrationDTO
+{
+    public function __construct(
+        public string  $sourceSystem,
+        public UserDTO $user,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            sourceSystem: $data['source_system'],
+            user: UserDTO::fromArray($data['user'], $data['source_system']),
+        );
+    }
+}

--- a/app/DTOs/Order/FinishOrderDTO.php
+++ b/app/DTOs/Order/FinishOrderDTO.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\DTOs\Order;
+
+use Illuminate\Http\Request;
+
+readonly class FinishOrderDTO
+{
+    public function __construct(
+        public ?string $justification = null,
+    ) {
+    }
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            justification: $request->input('justification'),
+        );
+    }
+}

--- a/app/DTOs/Order/ScheduleOrderDTO.php
+++ b/app/DTOs/Order/ScheduleOrderDTO.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\DTOs\Order;
+
+use App\Http\Requests\ScheduleOrderRequest;
+
+readonly class ScheduleOrderDTO
+{
+    public function __construct(
+        public string  $id,
+        public string  $scheduledAt,
+        public string  $status,
+        public ?string $dockId = null,
+        public ?string $operatorId = null,
+    ) {
+    }
+
+    public static function fromRequest(ScheduleOrderRequest $request): self
+    {
+        $validated = $request->validated();
+
+        return new self(
+            id: $validated['id'],
+            scheduledAt: $validated['scheduled_at'],
+            status: $validated['status'],
+            dockId: $validated['dock_id'] ?? null,
+            operatorId: $validated['operator_id'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id'           => $this->id,
+            'scheduled_at' => $this->scheduledAt,
+            'status'       => $this->status,
+            'dock_id'      => $this->dockId,
+            'operator_id'  => $this->operatorId,
+        ];
+    }
+}

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\DTOs\Order\FinishOrderDTO;
+use App\DTOs\Order\ScheduleOrderDTO;
 use App\Http\Requests\ScheduleOrderRequest;
 use App\Http\Resources\LoadingOrderResource;
 use App\Services\OrderService;
@@ -105,7 +107,8 @@ class OrderController extends Controller
     public function scheduleOrder(ScheduleOrderRequest $request): \Illuminate\Http\JsonResponse
     {
         try {
-            $order = $this->orderService->scheduleOrder(auth()->user(), $request->validated());
+            $dto = ScheduleOrderDTO::fromRequest($request);
+            $this->orderService->scheduleOrder(auth()->user(), $dto);
 
             return response()->json([
                 'success' => true,
@@ -147,7 +150,7 @@ class OrderController extends Controller
     public function startOrder($orderId): \Illuminate\Http\JsonResponse
     {
         try {
-            $order = $this->orderService->startOrder(auth()->user(), $orderId);
+            $this->orderService->startOrder(auth()->user(), $orderId);
 
             return response()->json([
                 'success' => true,
@@ -195,11 +198,11 @@ class OrderController extends Controller
             new OA\Response(response: 500, description: "Erro interno no servidor")
         ]
     )]
-    public function finishOrder(Request $request, $orderId): \Illuminate\Http\JsonResponse    {
+    public function finishOrder(Request $request, $orderId): \Illuminate\Http\JsonResponse
+    {
         try {
-            $justification = $request->input('justification');
-
-            $order = $this->orderService->finishOrder(auth()->user(), $orderId, $justification);
+            $dto = FinishOrderDTO::fromRequest($request);
+            $this->orderService->finishOrder(auth()->user(), $orderId, $dto);
 
             return response()->json([
                 'success' => true,

--- a/app/Jobs/ProcessDockJob.php
+++ b/app/Jobs/ProcessDockJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\DTOs\Integration\DockIntegrationDTO;
 use App\Exceptions\IntegrationException;
 use App\Services\DockService;
 use App\Services\IntegrationLogService;
@@ -45,7 +46,8 @@ class ProcessDockJob implements ShouldQueue
     public function handle(DockService $service): void
     {
         try {
-            $service->storeDock($this->payload);
+            $dto = DockIntegrationDTO::fromArray($this->payload);
+            $service->storeDock($dto);
         } catch (IntegrationException $e) {
 
             /**

--- a/app/Jobs/ProcessLoadingOrderJob.php
+++ b/app/Jobs/ProcessLoadingOrderJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\DTOs\Integration\LoadingOrderIntegrationDTO;
 use App\Exceptions\IntegrationException;
 use App\Services\IntegrationLogService;
 use App\Services\LoadingOrderIntegrationService;
@@ -34,7 +35,8 @@ class ProcessLoadingOrderJob implements ShouldQueue
     {
         try {
 
-            $service->storeOrder($this->payload);
+            $dto = LoadingOrderIntegrationDTO::fromArray($this->payload);
+            $service->storeOrder($dto);
 
         } catch (IntegrationException $e) {
 

--- a/app/Jobs/ProcessUserJob.php
+++ b/app/Jobs/ProcessUserJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\DTOs\Integration\UserIntegrationDTO;
 use App\Exceptions\IntegrationException;
 use App\Services\IntegrationLogService;
 use App\Services\UserService;
@@ -43,7 +44,8 @@ class ProcessUserJob implements ShouldQueue
     {
         try {
 
-            $service->storeUser($this->payload);
+            $dto = UserIntegrationDTO::fromArray($this->payload);
+            $service->storeUser($dto);
 
         } catch (IntegrationException $e) {
 

--- a/app/Services/DockService.php
+++ b/app/Services/DockService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\DTOs\Entity\DockDTO;
+use App\DTOs\Integration\DockIntegrationDTO;
 use App\Enums\HttpStatus;
 use App\Exceptions\IntegrationException;
 use App\Models\Dock;
@@ -15,89 +17,45 @@ class DockService
     public function __construct(
         private readonly EntityService         $entityService,
         private readonly IntegrationLogService $logService
-    )
-    {
+    ) {
     }
 
     /**
-     * @param array $data
+     * @param DockIntegrationDTO $dto
      * @return void
      * @throws IntegrationException
      */
-    public function storeDock(array $data): void
+    public function storeDock(DockIntegrationDTO $dto): void
     {
         DB::beginTransaction();
         try {
-            $this->validateData($data);
-
-            $this->processDock($data);
+            $this->entityService->findOrCreateDock($dto->dock);
 
             DB::commit();
 
             $this->logService->log(
                 self::ENDPOINT,
-                $data,
+                ['source_system' => $dto->sourceSystem, 'dock_code' => $dto->dock->dockCode],
                 HttpStatus::OK->value,
                 null
             );
 
         } catch (IntegrationException $e) {
             DB::rollBack();
-            $this->logError($data, $e->getHttpStatus(), $e->getMessage());
+            $this->logError(['source_system' => $dto->sourceSystem], $e->getHttpStatus(), $e->getMessage());
             throw $e;
         } catch (\Exception $e) {
             DB::rollBack();
             Log::error('Erro inesperado na integração de dock', [
                 'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString()
+                'trace'   => $e->getTraceAsString(),
             ]);
-            $this->logError($data, HttpStatus::INTERNAL_SERVER_ERROR->value, $e->getMessage());
+            $this->logError(['source_system' => $dto->sourceSystem], HttpStatus::INTERNAL_SERVER_ERROR->value, $e->getMessage());
             throw new IntegrationException(
                 'Erro interno ao processar integração',
                 HttpStatus::INTERNAL_SERVER_ERROR->value
             );
         }
-    }
-
-    /**
-     * @throws IntegrationException
-     */
-    private function validateData(array $data): void
-    {
-        if (empty($data['dock']['external_id'])) {
-            throw new IntegrationException(
-                'Dados de dock inválidos: external_id é obrigatório',
-                HttpStatus::BAD_REQUEST->value
-            );
-        }
-
-        if (empty($data['dock']['dock_code'])) {
-            throw new IntegrationException(
-                'Dados de dock inválidos: dock_code é obrigatório',
-                HttpStatus::BAD_REQUEST->value
-            );
-        }
-
-        if (empty($data['source_system'])) {
-            throw new IntegrationException(
-                'Dados de dock inválidos: source_system é obrigatório',
-                HttpStatus::BAD_REQUEST->value
-            );
-        }
-    }
-
-    private function processDock(array $data): void
-    {
-        $dock = $data['dock'];
-        $sourceSystem = $data['source_system'];
-
-        $this->entityService->findOrCreateDock([
-                'external_id' => $dock['external_id'],
-                'source_system' => $sourceSystem,
-                'dock_code' => $dock['dock_code'],
-                'description' => $dock['description'] ?? null,
-                'location' => $dock['location'] ?? null]
-        );
     }
 
     public function getAllDocks(): \Illuminate\Database\Eloquent\Collection

--- a/app/Services/EntityService.php
+++ b/app/Services/EntityService.php
@@ -2,6 +2,14 @@
 
 namespace App\Services;
 
+use App\DTOs\Entity\CarrierDTO;
+use App\DTOs\Entity\CustomerDTO;
+use App\DTOs\Entity\DestinationDTO;
+use App\DTOs\Entity\DockDTO;
+use App\DTOs\Entity\DriverDTO;
+use App\DTOs\Entity\ProductDTO;
+use App\DTOs\Entity\UserDTO;
+use App\DTOs\Entity\VehicleDTO;
 use App\Models\Carrier;
 use App\Models\Customer;
 use App\Models\Destination;
@@ -14,283 +22,261 @@ use Illuminate\Support\Facades\Hash;
 
 class EntityService
 {
-    public function findOrCreateCustomer(array $data)
+    public function findOrCreateCustomer(CustomerDTO $dto): Customer
     {
-        if (!empty($data['external_id'])) {
-            $customer = Customer::query()->where('external_id', $data['external_id'])
-                ->first();
-
-            if ($customer) {
-                $customer->update(
-                    [
-                        'name' => $data['name'],
-                        'email' => $data['email'],
-                        'phone' => $data['phone'],
-                    ]
-                );
-                return $customer;
-            }
-        }
-
-        if (!empty($data['document'])) {
-            $customer = Customer::query()->where('document', $data['document'])->first();
+        if (!empty($dto->externalId)) {
+            $customer = Customer::query()->where('external_id', $dto->externalId)->first();
 
             if ($customer) {
                 $customer->update([
-                    'external_id' => $data['external_id'] ?? null,
-                    'source_system' => $data['source_system'] ?? null,
+                    'name'  => $dto->name,
+                    'email' => $dto->email,
+                    'phone' => $dto->phone,
                 ]);
                 return $customer;
             }
         }
 
-        return Customer::query()->create(
-            [
-                'external_id' => $data['external_id'] ?? null,
-                'source_system' => $data['source_system'] ?? null,
-                'name' => $data['name'],
-                'document' => $data['document'] ?? null,
-                'email' => $data['email'] ?? null,
-                'phone' => $data['phone'] ?? null,
-            ]
-        );
+        if (!empty($dto->document)) {
+            $customer = Customer::query()->where('document', $dto->document)->first();
+
+            if ($customer) {
+                $customer->update([
+                    'external_id'   => $dto->externalId ?? null,
+                    'source_system' => $dto->sourceSystem ?? null,
+                ]);
+                return $customer;
+            }
+        }
+
+        return Customer::query()->create([
+            'external_id'   => $dto->externalId ?? null,
+            'source_system' => $dto->sourceSystem ?? null,
+            'name'          => $dto->name,
+            'document'      => $dto->document ?? null,
+            'email'         => $dto->email ?? null,
+            'phone'         => $dto->phone ?? null,
+        ]);
     }
 
-    public function findOrCreateDestination(array $data): Destination
+    public function findOrCreateDestination(DestinationDTO $dto): Destination
     {
-        if (!empty($data['external_id'])) {
-            $destination = Destination::query()->where('external_id', $data['external_id'])
-                ->first();
+        if (!empty($dto->externalId)) {
+            $destination = Destination::query()->where('external_id', $dto->externalId)->first();
 
             if ($destination) {
                 $destination->update([
-                    'name' => $data['name'],
-                    'address' => $data['address'] ?? null,
-                    'city' => $data['city'] ?? null,
-                    'state' => $data['state'] ?? null,
+                    'name'    => $dto->name,
+                    'address' => $dto->address ?? null,
+                    'city'    => $dto->city ?? null,
+                    'state'   => $dto->state ?? null,
                 ]);
                 return $destination;
             }
         }
 
-        if (!empty($data['postal_code'])) {
-            $destination = Destination::query()->where('postal_code', $data['postal_code'])
-                ->where('name', $data['name'])
+        if (!empty($dto->postalCode)) {
+            $destination = Destination::query()
+                ->where('postal_code', $dto->postalCode)
+                ->where('name', $dto->name)
                 ->first();
 
             if ($destination) {
                 $destination->update([
-                    'external_id' => $data['external_id'] ?? null,
-                    'source_system' => $data['source_system'] ?? null,
+                    'external_id'   => $dto->externalId ?? null,
+                    'source_system' => $dto->sourceSystem ?? null,
                 ]);
                 return $destination;
             }
         }
 
-        return Destination::query()->create(
-            [
-                'external_id' => $data['external_id'] ?? null,
-                'source_system' => $data['source_system'] ?? null,
-                'name' => $data['name'],
-                'address' => $data['address'] ?? null,
-                'city' => $data['city'] ?? null,
-                'state' => $data['state'] ?? null,
-                'postal_code' => $data['postal_code'] ?? null,
-            ]
-        );
+        return Destination::query()->create([
+            'external_id'   => $dto->externalId ?? null,
+            'source_system' => $dto->sourceSystem ?? null,
+            'name'          => $dto->name,
+            'address'       => $dto->address ?? null,
+            'city'          => $dto->city ?? null,
+            'state'         => $dto->state ?? null,
+            'postal_code'   => $dto->postalCode ?? null,
+        ]);
     }
 
-    public function findOrCreateCarrier(array $data): Carrier
+    public function findOrCreateCarrier(CarrierDTO $dto): Carrier
     {
-        if (!empty($data['external_id'])) {
-            $carrier = Carrier::query()->where('external_id', $data['external_id'])
-                ->first();
+        if (!empty($dto->externalId)) {
+            $carrier = Carrier::query()->where('external_id', $dto->externalId)->first();
 
             if ($carrier) {
-                $carrier->update(
-                    [
-                        'name' => $data['name'],
-                        'document' => $data['document'] ?? null,
-                        'contact_phone' => $data['contact_phone'] ?? null,
-                    ]
-                );
+                $carrier->update([
+                    'name'          => $dto->name,
+                    'document'      => $dto->document ?? null,
+                    'contact_phone' => $dto->contactPhone ?? null,
+                ]);
                 return $carrier;
             }
         }
 
-        if (!empty($data['document'])) {
-            $carrier = Carrier::query()->where('document', $data['document'])->first();
+        if (!empty($dto->document)) {
+            $carrier = Carrier::query()->where('document', $dto->document)->first();
 
             if ($carrier) {
                 $carrier->update([
-                    'external_id' => $data['external_id'] ?? null,
-                    'source_system' => $data['source_system'] ?? null,
+                    'external_id'   => $dto->externalId ?? null,
+                    'source_system' => $dto->sourceSystem ?? null,
                 ]);
                 return $carrier;
             }
         }
 
         return Carrier::query()->create([
-            'external_id' => $data['external_id'] ?? null,
-            'source_system' => $data['source_system'] ?? null,
-            'name' => $data['name'],
-            'document' => $data['document'] ?? null,
-            'contact_phone' => $data['contact_phone'] ?? null,
+            'external_id'   => $dto->externalId ?? null,
+            'source_system' => $dto->sourceSystem ?? null,
+            'name'          => $dto->name,
+            'document'      => $dto->document ?? null,
+            'contact_phone' => $dto->contactPhone ?? null,
         ]);
     }
 
-    public function findOrCreateVehicle(array $data): Vehicle
+    public function findOrCreateVehicle(VehicleDTO $dto): Vehicle
     {
-        if (!empty($data['external_id'])) {
-            $vehicle = Vehicle::query()->where('external_id', $data['external_id'])
-                ->first();
-
-            if ($vehicle) {
-                $vehicle->update(
-                    [
-                        'vehiclePlate' => $data['vehiclePlate'],
-                        'model' => $data['model'] ?? null,
-                        'capacity' => $data['capacity'] ?? null,
-                    ]
-                );
-                return $vehicle;
-            }
-        }
-
-        if (!empty($data['vehiclePlate'])) {
-            $vehicle = Vehicle::query()->where('vehiclePlate', $data['vehiclePlate'])->first();
+        if (!empty($dto->externalId)) {
+            $vehicle = Vehicle::query()->where('external_id', $dto->externalId)->first();
 
             if ($vehicle) {
                 $vehicle->update([
-                    'external_id' => $data['external_id'] ?? null,
-                    'source_system' => $data['source_system'] ?? null,
+                    'vehiclePlate' => $dto->vehiclePlate,
+                    'model'        => $dto->model ?? null,
                 ]);
                 return $vehicle;
             }
         }
 
+        if (!empty($dto->vehiclePlate)) {
+            $vehicle = Vehicle::query()->where('vehiclePlate', $dto->vehiclePlate)->first();
 
-        return Vehicle::query()->create([
-            'external_id' => $data['external_id'],
-            'source_system' => $data['source_system'],
-            'vehiclePlate' => $data['vehiclePlate'],
-            'model' => $data['model'] ?? null,
-            'carrier_id' => $data['carrier_id'],
-        ]);
-    }
-
-    public function findOrCreateDriver(array $data): Driver
-    {
-        if (!empty($data['external_id'])) {
-            $driver = Driver::query()->where('external_id', $data['external_id'])
-                ->first();
-
-            if ($driver) {
-                $driver->update(
-                    [
-                        'name' => $data['name'],
-                        'document' => $data['document'] ?? null,
-                        'phone' => $data['phone'] ?? null,
-                    ]
-                );
-                return $driver;
+            if ($vehicle) {
+                $vehicle->update([
+                    'external_id'   => $dto->externalId ?? null,
+                    'source_system' => $dto->sourceSystem ?? null,
+                ]);
+                return $vehicle;
             }
         }
 
-        if (!empty($data['document'])) {
-            $driver = Driver::query()->where('document', $data['document'])->first();
+        return Vehicle::query()->create([
+            'external_id'   => $dto->externalId,
+            'source_system' => $dto->sourceSystem,
+            'vehiclePlate'  => $dto->vehiclePlate,
+            'model'         => $dto->model ?? null,
+            'carrier_id'    => $dto->carrierId,
+        ]);
+    }
+
+    public function findOrCreateDriver(DriverDTO $dto): Driver
+    {
+        if (!empty($dto->externalId)) {
+            $driver = Driver::query()->where('external_id', $dto->externalId)->first();
 
             if ($driver) {
                 $driver->update([
-                    'external_id' => $data['external_id'] ?? null,
-                    'source_system' => $data['source_system'] ?? null,
+                    'name'     => $dto->name,
+                    'document' => $dto->document ?? null,
+                    'phone'    => $dto->phone ?? null,
                 ]);
                 return $driver;
             }
         }
 
-        //dd($data);
+        if (!empty($dto->document)) {
+            $driver = Driver::query()->where('document', $dto->document)->first();
+
+            if ($driver) {
+                $driver->update([
+                    'external_id'   => $dto->externalId ?? null,
+                    'source_system' => $dto->sourceSystem ?? null,
+                ]);
+                return $driver;
+            }
+        }
 
         return Driver::query()->create([
-            'external_id' => $data['external_id'] ?? null,
-            'source_system' => $data['source_system'] ?? null,
-            'name' => $data['name'],
-            'document' => $data['document'],
-            'phone' => $data['phone'] ?? null,
-            'carrier_id' => $data['carrier_id'],
+            'external_id'   => $dto->externalId ?? null,
+            'source_system' => $dto->sourceSystem ?? null,
+            'name'          => $dto->name,
+            'document'      => $dto->document,
+            'phone'         => $dto->phone ?? null,
+            'carrier_id'    => $dto->carrierId,
         ]);
     }
 
-    public function findOrCreateProduct(array $data): Product
+    public function findOrCreateProduct(ProductDTO $dto): Product
     {
-        $product = Product::query()->where('sku', $data['product_sku'])->first();
+        $product = Product::query()->where('sku', $dto->sku)->first();
 
         if ($product) {
             $product->update([
-                'description' => $data['description'],
-                'weight' => $data['weight'] ?? null,
-                'unit' => $data['unit'] ?? 'un',
-                'barcode' => $data['barcode'] ?? null,
+                'description' => $dto->description,
+                'weight'      => $dto->weight ?? null,
+                'unit'        => $dto->unit ?? 'un',
+                'barcode'     => $dto->barcode ?? null,
             ]);
             return $product;
         }
 
         return Product::query()->create([
-            'sku' => $data['product_sku'],
-            'description' => $data['description'],
-            'weight' => $data['weight'] ?? null,
-            'unit' => $data['unit'] ?? 'un',
-            'barcode' => $data['barcode'] ?? null,
+            'sku'         => $dto->sku,
+            'description' => $dto->description,
+            'weight'      => $dto->weight ?? null,
+            'unit'        => $dto->unit ?? 'un',
+            'barcode'     => $dto->barcode ?? null,
         ]);
     }
 
-    public function findOrCreateUser(array $data): User
+    public function findOrCreateUser(UserDTO $dto): User
     {
-        $user = User::query()->where('email', $data['email'])->first();
+        $user = User::query()->where('email', $dto->email)->first();
 
         if ($user) {
             $user->update([
-                'name' => $data['name'],
-                'external_id' => $data['external_id'] ?? null,
-                'source_system' => $data['source_system'] ?? null,
+                'name'          => $dto->name,
+                'external_id'   => $dto->externalId ?? null,
+                'source_system' => $dto->sourceSystem ?? null,
             ]);
             return $user;
         }
 
-        $password = Hash::make('Expedisoft' . $data['email']);
+        $password = Hash::make('Expedisoft' . $dto->email);
 
-        //dd($password);
         return User::query()->create([
-            'name' => $data['name'],
-            'email' => $data['email'],
-            'external_id' => $data['external_id'] ?? null,
-            'source_system' => $data['source_system'] ?? null,
-            'password' => $password,
+            'name'          => $dto->name,
+            'email'         => $dto->email,
+            'external_id'   => $dto->externalId ?? null,
+            'source_system' => $dto->sourceSystem ?? null,
+            'password'      => $password,
         ]);
     }
 
-    public function findOrCreateDock(array $data): Dock
+    public function findOrCreateDock(DockDTO $dto): Dock
     {
-        $dock = Dock::query()->where('external_id', $data['external_id'])
-            ->first();
+        $dock = Dock::query()->where('external_id', $dto->externalId)->first();
 
         if ($dock) {
             $dock->update([
-                'dock_code' => $data['dock_code'],
-                'description' => $data['description'] ?? null,
-                'location' => $data['location'] ?? null,
-                'external_id' => $data['external_id'] ?? null,
-                'source_system' => $data['source_system'] ?? null,
+                'dock_code'     => $dto->dockCode,
+                'description'   => $dto->description ?? null,
+                'location'      => $dto->location ?? null,
+                'external_id'   => $dto->externalId ?? null,
+                'source_system' => $dto->sourceSystem ?? null,
             ]);
             return $dock;
         }
 
         return Dock::query()->create([
-            'external_id' => $data['external_id'] ?? null,
-            'source_system' => $data['source_system'] ?? null,
-            'dock_code' => $data['dock_code'],
-            'description' => $data['description'] ?? null,
-            'location' => $data['location'] ?? null,
+            'external_id'   => $dto->externalId ?? null,
+            'source_system' => $dto->sourceSystem ?? null,
+            'dock_code'     => $dto->dockCode,
+            'description'   => $dto->description ?? null,
+            'location'      => $dto->location ?? null,
         ]);
     }
 }

--- a/app/Services/LoadingOrderIntegrationService.php
+++ b/app/Services/LoadingOrderIntegrationService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services;
 
-
+use App\DTOs\Entity\VehicleDTO;
+use App\DTOs\Entity\DriverDTO;
+use App\DTOs\Integration\LoadingOrderIntegrationDTO;
 use App\Enums\HttpStatus;
 use App\Exceptions\IntegrationException;
 use App\Models\LoadingOrder;
@@ -11,111 +13,71 @@ use Illuminate\Support\Facades\Log;
 
 readonly class LoadingOrderIntegrationService
 {
-
-    //protected EntityService $entityService;
-
     private const ENDPOINT = '/api/integration/order';
 
     public function __construct(private EntityService $entityService, private IntegrationLogService $logService)
     {
-        //$this->entityService = $entityService;
-
     }
 
     /**
-     * @param array $payload
+     * @param LoadingOrderIntegrationDTO $dto
      * @return LoadingOrder
      * @throws IntegrationException|\Exception
      */
-    public function storeOrder(array $payload): LoadingOrder
+    public function storeOrder(LoadingOrderIntegrationDTO $dto): LoadingOrder
     {
         DB::beginTransaction();
         try {
+            $customer    = $this->entityService->findOrCreateCustomer($dto->customer);
+            $destination = $this->entityService->findOrCreateDestination($dto->destination);
+            $carrier     = $this->entityService->findOrCreateCarrier($dto->carrier);
 
-            $this->validateData($payload);
+            // Injeta o carrier_id nos DTOs de veículo e motorista
+            $vehicleDto = new VehicleDTO(
+                vehiclePlate: $dto->vehicle->vehiclePlate,
+                carrierId: $carrier->id,
+                externalId: $dto->vehicle->externalId,
+                sourceSystem: $dto->vehicle->sourceSystem,
+                model: $dto->vehicle->model,
+            );
 
-            $sourceSystem = $payload['source_system'];
-            $orderData = $payload['loadingOrder'];
+            $driverDto = new DriverDTO(
+                name: $dto->driver->name,
+                carrierId: $carrier->id,
+                externalId: $dto->driver->externalId,
+                sourceSystem: $dto->driver->sourceSystem,
+                document: $dto->driver->document,
+                phone: $dto->driver->phone,
+            );
 
-            //dd($orderData);
-            $customer = $this->entityService->findOrCreateCustomer([
-                'external_id' => $orderData['customer']['external_id'],
-                'source_system' => $sourceSystem,
-                'name' => $orderData['customer']['name'],
-                'email' => $orderData['customer']['email'] ?? null,
-                'phone' => $orderData['customer']['phone'] ?? null,
-                'address' => $orderData['customer']['address'] ?? null,
-            ]);
-
-            $destination = $this->entityService->findOrCreateDestination([
-                'external_id' => $orderData['destination']['external_id'],
-                'source_system' => $sourceSystem,
-                'name' => $orderData['destination']['name'],
-                'address' => $orderData['destination']['address'] ?? null,
-                'postal_code' => $orderData['destination']['postal_code'] ?? null,
-                'city' => $orderData['destination']['city'] ?? null,
-                'state' => $orderData['destination']['state'] ?? null,
-            ]);
-
-            $carrier = $this->entityService->findOrCreateCarrier([
-                'external_id' => $orderData['carrier']['external_id'],
-                'source_system' => $sourceSystem ?? null,
-                'name' => $orderData['carrier']['name'],
-                'document' => $orderData['carrier']['document'] ?? null,
-                'contact_phone' => $orderData['carrier']['phone'] ?? null,
-            ]);
-
-            $vehicle = $this->entityService->findOrCreateVehicle([
-                'external_id' => $orderData['vehicle']['external_id'] ?? null,
-                'source_system' => $sourceSystem ?? null,
-                'vehiclePlate' => $orderData['vehicle']['vehiclePlate'],
-                'model' => $orderData['vehicle']['model'] ?? null,
-                'carrier_id' => $carrier->id,
-            ]);
-
-            //dd($orderData['driver']);
-
-            $driver = $this->entityService->findOrCreateDriver([
-                'external_id' => $orderData['driver']['external_id'] ?? null,
-                'source_system' => $sourceSystem ?? null,
-                'name' => $orderData['driver']['name'],
-                'document' => $orderData['driver']['document'] ?? null,
-                'phone' => $orderData['driver']['phone'] ?? null,
-                'carrier_id' => $carrier->id,
-            ]);
+            $vehicle = $this->entityService->findOrCreateVehicle($vehicleDto);
+            $driver  = $this->entityService->findOrCreateDriver($driverDto);
 
             $order = LoadingOrder::query()->create([
-                'external_id' => $orderData['external_id'] ?? null,
-                'observations' => $orderData['notes'] ?? null,
-                'source_system' => $sourceSystem ?? null,
-                'issue_date' => $orderData['issue_date'],
-                'status' => $orderData['status'] ?? 'pending',
-                'customer_id' => $customer->id,
+                'external_id'    => $dto->externalId,
+                'observations'   => $dto->notes ?? null,
+                'source_system'  => $dto->sourceSystem ?? null,
+                'issue_date'     => $dto->issueDate,
+                'status'         => $dto->status,
+                'customer_id'    => $customer->id,
                 'destination_id' => $destination->id,
-                'carrier_id' => $carrier->id,
-                'vehicle_id' => $vehicle->id,
-                'driver_id' => $driver->id,
+                'carrier_id'     => $carrier->id,
+                'vehicle_id'     => $vehicle->id,
+                'driver_id'      => $driver->id,
             ]);
 
-            foreach ($orderData['items'] as $item) {
-                $product = $this->entityService->findOrCreateProduct([
-                    'product_sku' => $item['product_sku'],
-                    'description' => $item['product_description'],
-                    'unit' => $item['unit'] ?? 'un',
-                ]);
-
+            foreach ($dto->items as $itemDto) {
+                $product   = $this->entityService->findOrCreateProduct($itemDto->product);
                 $orderItem = $order->items()->create([
                     'product_id' => $product->id,
-                    'quantity' => $item['quantity'],
+                    'quantity'   => $itemDto->quantity,
                 ]);
 
-                if (!empty($item['packages']) && is_array($item['packages'])) {
-                    foreach ($item['packages'] as $package) {
-                        $orderItem->packages()->firstOrCreate(
-                            ['unique_package_code' => $package['unique_package_code']],
-                            ['quantity_in_package' => $package['quantity_in_package'] ?? 1]
-                        );
-                    }
+                foreach ($itemDto->packages as $packageDto) {
+                    $orderItem->packages()->firstOrCreate(
+                        ['unique_package_code'   => $packageDto->uniquePackageCode],
+                        ['quantity_in_package'   => $packageDto->quantityInPackage]
+                    );
                 }
             }
 
@@ -123,23 +85,24 @@ readonly class LoadingOrderIntegrationService
 
             $this->logService->log(
                 self::ENDPOINT,
-                $payload,
+                $this->dtoToLogArray($dto),
                 HttpStatus::CREATED->value,
                 null
             );
 
             return $order;
+
         } catch (IntegrationException $e) {
             DB::rollBack();
-            $this->LogError($payload, $e->getHttpStatus(), $e->getMessage());
+            $this->logError($this->dtoToLogArray($dto), $e->getHttpStatus(), $e->getMessage());
             throw $e;
         } catch (\Exception $e) {
             DB::rollBack();
             Log::error('Erro inesperado na integração de ordem de carregamento', [
                 'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString()
+                'trace'   => $e->getTraceAsString(),
             ]);
-            $this->LogError($payload, HttpStatus::INTERNAL_SERVER_ERROR->value, $e->getMessage());
+            $this->logError($this->dtoToLogArray($dto), HttpStatus::INTERNAL_SERVER_ERROR->value, $e->getMessage());
             throw new IntegrationException(
                 'Erro interno ao processar a integração',
                 HttpStatus::INTERNAL_SERVER_ERROR->value
@@ -147,82 +110,12 @@ readonly class LoadingOrderIntegrationService
         }
     }
 
-    /**
-     * @throws IntegrationException
-     */
-    private function validateData(array $payload): void
+    private function dtoToLogArray(LoadingOrderIntegrationDTO $dto): array
     {
-        if (empty($payload['source_system'])) {
-            throw new IntegrationException(
-                'Sistema de origem não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($payload['loadingOrder'])) {
-            throw new IntegrationException(
-                'Dados da ordem de carregamento não informados',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        $orderData = $payload['loadingOrder'];
-
-        if (empty($orderData['external_id'])) {
-            throw new IntegrationException(
-                'ID externo da ordem de carregamento não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['issue_date'])) {
-            throw new IntegrationException(
-                'Data de emissão da ordem de carregamento não informada',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['customer']['external_id'])) {
-            throw new IntegrationException(
-                'ID externo do cliente não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['destination']['external_id'])) {
-            throw new IntegrationException(
-                'ID externo do destino não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['carrier']['external_id'])) {
-            throw new IntegrationException(
-                'ID externo do transportador não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['vehicle']['external_id'])) {
-            throw new IntegrationException(
-                'ID externo do veículo não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['driver']['external_id'])) {
-            throw new IntegrationException(
-                'ID externo do motorista não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($orderData['items']) || !is_array($orderData['items'])) {
-            throw new IntegrationException(
-                'Itens da ordem de carregamento não informados ou formato inválido',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
+        return [
+            'source_system' => $dto->sourceSystem,
+            'external_id'   => $dto->externalId,
+        ];
     }
 
     private function logError(array $payload, int $httpStatus, string $message): void
@@ -234,5 +127,4 @@ readonly class LoadingOrderIntegrationService
             $message
         );
     }
-
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\DTOs\Order\FinishOrderDTO;
+use App\DTOs\Order\ScheduleOrderDTO;
 use App\Models\LoadingOrder;
 use App\Models\OrderStatusHistory;
 use App\Models\User;
@@ -34,12 +36,12 @@ class OrderService
     /**
      * @throws AuthorizationException
      */
-    public function scheduleOrder(User $user, array $payload): LoadingOrder
+    public function scheduleOrder(User $user, ScheduleOrderDTO $dto): LoadingOrder
     {
-        $order = LoadingOrder::query()->findOrFail($payload['id']);
+        $order = LoadingOrder::query()->findOrFail($dto->id);
 
-        if (isset($payload['operator_id'])) {
-            $targetOperator = User::query()->findOrFail($payload['operator_id']);
+        if (isset($dto->operatorId)) {
+            $targetOperator = User::query()->findOrFail($dto->operatorId);
 
             if ($targetOperator->rule !== 'operador') {
                 throw new AuthorizationException('O usuário selecionado não possui permissão de operador.');
@@ -47,13 +49,13 @@ class OrderService
         }
 
         $updateData = [
-            'scheduled_at' => $payload['scheduled_at'],
-            'dock_id'      => $payload['dock_id'] ?? $order->dock_id,
+            'scheduled_at' => $dto->scheduledAt,
+            'dock_id'      => $dto->dockId ?? $order->dock_id,
             'created_by'   => $user->id,
-            'operator_id'  => $payload['operator_id'] ?? $order->operator_id,
+            'operator_id'  => $dto->operatorId ?? $order->operator_id,
         ];
 
-        return $this->updateOrderAndRecordHistory($order, $payload['status'], $user, $updateData);
+        return $this->updateOrderAndRecordHistory($order, $dto->status, $user, $updateData);
     }
 
     /**
@@ -81,7 +83,7 @@ class OrderService
     /**
      * @throws AuthorizationException
      */
-    public function finishOrder(User $operator, string $orderId, ?string $justification = null): LoadingOrder
+    public function finishOrder(User $operator, string $orderId, FinishOrderDTO $dto): LoadingOrder
     {
         $order = LoadingOrder::with('items.packages.checklistEntry')->findOrFail($orderId);
 
@@ -93,11 +95,11 @@ class OrderService
             throw new BadRequestException('A ordem de carregamento deve estar no status "in_progress" para ser finalizada.');
         }
 
-        $totalPackages = $order->items->flatMap->packages->count();
+        $totalPackages   = $order->items->flatMap->packages->count();
         $checkedPackages = $order->items->flatMap->packages->filter(fn ($package) => $package->checklistEntry !== null)->count();
-        $isDivergent = $checkedPackages < $totalPackages;
+        $isDivergent     = $checkedPackages < $totalPackages;
 
-        if ($isDivergent && empty($justification)) {
+        if ($isDivergent && empty($dto->justification)) {
             throw new BadRequestException('A justificativa é obrigatória para finalizar uma carga incompleta.');
         }
 
@@ -107,8 +109,8 @@ class OrderService
 
         $newStatus = $isDivergent ? 'divergence' : 'completed';
 
-        if (!empty($justification)) {
-            $updateData['justification'] = $justification;
+        if (!empty($dto->justification)) {
+            $updateData['justification'] = $dto->justification;
         }
 
         return $this->updateOrderAndRecordHistory($order, $newStatus, $operator, $updateData);

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use AllowDynamicProperties;
+use App\DTOs\Integration\UserIntegrationDTO;
+use App\DTOs\Entity\UserDTO;
 use App\Enums\HttpStatus;
 use App\Exceptions\IntegrationException;
 use App\Models\User;
@@ -11,34 +13,30 @@ use Illuminate\Support\Facades\Log;
 
 #[AllowDynamicProperties] class UserService
 {
-
     private const ENDPOINT = '/api/integration/user';
 
     public function __construct(
         private readonly EntityService         $entityService,
         private readonly IntegrationLogService $logService
-    )
-    {
+    ) {
     }
 
     /**
-     * @param array $data
+     * @param UserIntegrationDTO $dto
      * @return User
      * @throws IntegrationException
      */
-    public function storeUser(array $data): User
+    public function storeUser(UserIntegrationDTO $dto): User
     {
         DB::beginTransaction();
         try {
-            $this->validateData($data);
-
-            $user = $this->processUser($data);
+            $user = $this->entityService->findOrCreateUser($dto->user);
 
             DB::commit();
 
             $this->logService->log(
                 self::ENDPOINT,
-                $data,
+                ['source_system' => $dto->sourceSystem, 'email' => $dto->user->email],
                 HttpStatus::OK->value,
                 null
             );
@@ -47,53 +45,20 @@ use Illuminate\Support\Facades\Log;
 
         } catch (IntegrationException $e) {
             DB::rollBack();
-            $this->logError($data, $e->getHttpStatus(), $e->getMessage());
+            $this->logError(['source_system' => $dto->sourceSystem], $e->getHttpStatus(), $e->getMessage());
             throw $e;
         } catch (\Exception $e) {
             DB::rollBack();
             Log::error('Erro inesperado na integração de usuário', [
                 'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString()
+                'trace'   => $e->getTraceAsString(),
             ]);
-            $this->logError($data, HttpStatus::INTERNAL_SERVER_ERROR->value, $e->getMessage());
+            $this->logError(['source_system' => $dto->sourceSystem], HttpStatus::INTERNAL_SERVER_ERROR->value, $e->getMessage());
             throw new IntegrationException(
                 'Erro interno ao processar integração',
                 HttpStatus::INTERNAL_SERVER_ERROR->value
             );
         }
-    }
-
-    /**
-     * @throws IntegrationException
-     */
-    private function validateData(array $data): void
-    {
-        if (empty($data['user'])) {
-            throw new IntegrationException(
-                'Dados do usuário não informados',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-
-        if (empty($data['source_system'])) {
-            throw new IntegrationException(
-                'Sistema de origem não informado',
-                HttpStatus::UNPROCESSABLE_ENTITY->value
-            );
-        }
-    }
-
-    private function processUser(array $data): User
-    {
-        $userData = $data['user'];
-        $sourceSystem = $data['source_system'];
-
-        return $this->entityService->findOrCreateUser([
-            'external_id' => $userData['external_id'] ?? null,
-            'source_system' => $sourceSystem,
-            'name' => $userData['name'],
-            'email' => $userData['email'],
-        ]);
     }
 
     private function logError(array $data, int $httpStatus, string $message): void

--- a/tests/Unit/DTOs/Entity/CustomerDTOTest.php
+++ b/tests/Unit/DTOs/Entity/CustomerDTOTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit\DTOs\Entity;
+
+use App\DTOs\Entity\CustomerDTO;
+use Tests\TestCase;
+
+class CustomerDTOTest extends TestCase
+{
+    public function test_it_creates_dto_from_array_with_all_fields(): void
+    {
+        $data = [
+            'external_id'   => 'CUST-001',
+            'name'          => 'Cliente Exemplo Ltda',
+            'source_system' => 'ERP_A',
+            'document'      => '12345678000100',
+            'email'         => 'contato@cliente.com',
+            'phone'         => '11999999999',
+            'address'       => 'Rua das Flores, 123',
+        ];
+
+        $dto = CustomerDTO::fromArray($data);
+
+        $this->assertSame('CUST-001', $dto->externalId);
+        $this->assertSame('Cliente Exemplo Ltda', $dto->name);
+        $this->assertSame('ERP_A', $dto->sourceSystem);
+        $this->assertSame('12345678000100', $dto->document);
+        $this->assertSame('contato@cliente.com', $dto->email);
+        $this->assertSame('11999999999', $dto->phone);
+        $this->assertSame('Rua das Flores, 123', $dto->address);
+    }
+
+    public function test_it_accepts_source_system_from_parameter(): void
+    {
+        $data = [
+            'external_id' => 'CUST-002',
+            'name'        => 'Cliente B',
+        ];
+
+        $dto = CustomerDTO::fromArray($data, 'ERP_EXTERNO');
+
+        $this->assertSame('ERP_EXTERNO', $dto->sourceSystem);
+    }
+
+    public function test_array_source_system_takes_precedence(): void
+    {
+        $data = [
+            'external_id'   => 'CUST-003',
+            'name'          => 'Cliente C',
+            'source_system' => 'SOURCE_FROM_ARRAY',
+        ];
+
+        $dto = CustomerDTO::fromArray($data, 'SOURCE_FROM_PARAM');
+
+        $this->assertSame('SOURCE_FROM_ARRAY', $dto->sourceSystem);
+    }
+
+    public function test_optional_fields_default_to_null(): void
+    {
+        $dto = CustomerDTO::fromArray([
+            'external_id' => 'CUST-004',
+            'name'        => 'Cliente D',
+        ]);
+
+        $this->assertNull($dto->document);
+        $this->assertNull($dto->email);
+        $this->assertNull($dto->phone);
+        $this->assertNull($dto->address);
+        $this->assertNull($dto->sourceSystem);
+    }
+
+    public function test_to_array_returns_correct_structure(): void
+    {
+        $dto = new CustomerDTO(
+            externalId: 'CUST-005',
+            name: 'Cliente E',
+            sourceSystem: 'ERP',
+            email: 'e@mail.com',
+        );
+
+        $array = $dto->toArray();
+
+        $this->assertArrayHasKey('external_id', $array);
+        $this->assertArrayHasKey('source_system', $array);
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('email', $array);
+        $this->assertSame('CUST-005', $array['external_id']);
+    }
+
+    public function test_dto_is_readonly(): void
+    {
+        $dto = new CustomerDTO(externalId: 'ID', name: 'Name');
+
+        $this->expectException(\Error::class);
+        $dto->name = 'Changed'; // @phpstan-ignore-line
+    }
+}

--- a/tests/Unit/DTOs/Integration/DockIntegrationDTOTest.php
+++ b/tests/Unit/DTOs/Integration/DockIntegrationDTOTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\DTOs\Integration;
+
+use App\DTOs\Integration\DockIntegrationDTO;
+use Tests\TestCase;
+
+class DockIntegrationDTOTest extends TestCase
+{
+    private array $validPayload = [
+        'source_system' => 'ERP_SISTEMA_A',
+        'dock'          => [
+            'external_id' => 'DOCK-001',
+            'dock_code'   => 'D01',
+            'description' => 'Doca principal',
+            'location'    => 'Bloco A',
+        ],
+    ];
+
+    public function test_it_creates_dto_from_array(): void
+    {
+        $dto = DockIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertSame('ERP_SISTEMA_A', $dto->sourceSystem);
+        $this->assertSame('DOCK-001', $dto->dock->externalId);
+        $this->assertSame('D01', $dto->dock->dockCode);
+        $this->assertSame('Doca principal', $dto->dock->description);
+        $this->assertSame('Bloco A', $dto->dock->location);
+        $this->assertSame('ERP_SISTEMA_A', $dto->dock->sourceSystem);
+    }
+
+    public function test_it_handles_optional_dock_fields(): void
+    {
+        $payload = [
+            'source_system' => 'ERP_SISTEMA_A',
+            'dock'          => [
+                'external_id' => 'DOCK-002',
+                'dock_code'   => 'D02',
+            ],
+        ];
+
+        $dto = DockIntegrationDTO::fromArray($payload);
+
+        $this->assertNull($dto->dock->description);
+        $this->assertNull($dto->dock->location);
+    }
+
+    public function test_dto_is_readonly(): void
+    {
+        $dto = DockIntegrationDTO::fromArray($this->validPayload);
+
+        $this->expectException(\Error::class);
+        $dto->sourceSystem = 'OTHER'; // @phpstan-ignore-line
+    }
+}

--- a/tests/Unit/DTOs/Integration/LoadingOrderIntegrationDTOTest.php
+++ b/tests/Unit/DTOs/Integration/LoadingOrderIntegrationDTOTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit\DTOs\Integration;
+
+use App\DTOs\Integration\LoadingOrderIntegrationDTO;
+use Tests\TestCase;
+
+class LoadingOrderIntegrationDTOTest extends TestCase
+{
+    private array $validPayload;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validPayload = [
+            'source_system' => 'ERP_A',
+            'loadingOrder'  => [
+                'external_id' => 'DOC-001',
+                'issue_date'  => '2025-01-07',
+                'status'      => 'pending',
+                'notes'       => 'Observação de teste',
+                'customer'    => [
+                    'external_id' => 'CUST-01',
+                    'name'        => 'Cliente Teste',
+                    'email'       => 'cliente@teste.com',
+                    'phone'       => '11999999999',
+                ],
+                'destination' => [
+                    'external_id' => 'DEST-01',
+                    'name'        => 'CD Sul',
+                    'city'        => 'Porto Alegre',
+                    'state'       => 'RS',
+                    'postal_code' => '90000000',
+                ],
+                'carrier' => [
+                    'external_id' => 'CARR-01',
+                    'name'        => 'Transportadora X',
+                    'document'    => '12345678000100',
+                    'phone'       => '11988888888',
+                ],
+                'vehicle' => [
+                    'external_id'  => 'VEH-01',
+                    'vehiclePlate' => 'ABC1234',
+                    'model'        => 'Truck 2022',
+                ],
+                'driver' => [
+                    'external_id' => 'DRV-01',
+                    'name'        => 'Motorista Teste',
+                    'document'    => '12345678900',
+                    'phone'       => '11977777777',
+                ],
+                'items' => [
+                    [
+                        'product_sku'         => 'SKU-001',
+                        'product_description' => 'Produto Teste',
+                        'quantity'            => 10,
+                        'unit'                => 'un',
+                        'packages'            => [
+                            [
+                                'unique_package_code'  => 'PKG-001',
+                                'quantity_in_package'  => 5,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function test_it_creates_dto_from_array(): void
+    {
+        $dto = LoadingOrderIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertSame('ERP_A', $dto->sourceSystem);
+        $this->assertSame('DOC-001', $dto->externalId);
+        $this->assertSame('2025-01-07', $dto->issueDate);
+        $this->assertSame('pending', $dto->status);
+        $this->assertSame('Observação de teste', $dto->notes);
+    }
+
+    public function test_it_maps_customer_correctly(): void
+    {
+        $dto = LoadingOrderIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertSame('CUST-01', $dto->customer->externalId);
+        $this->assertSame('Cliente Teste', $dto->customer->name);
+        $this->assertSame('ERP_A', $dto->customer->sourceSystem);
+    }
+
+    public function test_it_maps_destination_correctly(): void
+    {
+        $dto = LoadingOrderIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertSame('DEST-01', $dto->destination->externalId);
+        $this->assertSame('CD Sul', $dto->destination->name);
+        $this->assertSame('RS', $dto->destination->state);
+    }
+
+    public function test_it_maps_items_and_packages_correctly(): void
+    {
+        $dto = LoadingOrderIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertCount(1, $dto->items);
+
+        $item = $dto->items[0];
+        $this->assertSame('SKU-001', $item->product->sku);
+        $this->assertSame(10, $item->quantity);
+        $this->assertCount(1, $item->packages);
+        $this->assertSame('PKG-001', $item->packages[0]->uniquePackageCode);
+        $this->assertSame(5, $item->packages[0]->quantityInPackage);
+    }
+
+    public function test_it_handles_items_with_no_packages(): void
+    {
+        $this->validPayload['loadingOrder']['items'][0]['packages'] = [];
+
+        $dto = LoadingOrderIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertCount(0, $dto->items[0]->packages);
+    }
+
+    public function test_status_defaults_to_pending_when_not_provided(): void
+    {
+        unset($this->validPayload['loadingOrder']['status']);
+        $this->validPayload['loadingOrder']['status'] = null;
+
+        // Recria com status null → deve usar default 'pending'
+        $payload = $this->validPayload;
+        $payload['loadingOrder']['status'] = null;
+
+        $dto = LoadingOrderIntegrationDTO::fromArray($payload);
+
+        $this->assertSame('pending', $dto->status);
+    }
+}

--- a/tests/Unit/DTOs/Integration/UserIntegrationDTOTest.php
+++ b/tests/Unit/DTOs/Integration/UserIntegrationDTOTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\DTOs\Integration;
+
+use App\DTOs\Integration\UserIntegrationDTO;
+use Tests\TestCase;
+
+class UserIntegrationDTOTest extends TestCase
+{
+    private array $validPayload = [
+        'source_system' => 'SAP',
+        'user'          => [
+            'external_id' => 'USER-99',
+            'name'        => 'João Silva',
+            'email'       => 'joao@empresa.com',
+        ],
+    ];
+
+    public function test_it_creates_dto_from_array(): void
+    {
+        $dto = UserIntegrationDTO::fromArray($this->validPayload);
+
+        $this->assertSame('SAP', $dto->sourceSystem);
+        $this->assertSame('USER-99', $dto->user->externalId);
+        $this->assertSame('João Silva', $dto->user->name);
+        $this->assertSame('joao@empresa.com', $dto->user->email);
+        $this->assertSame('SAP', $dto->user->sourceSystem);
+    }
+
+    public function test_it_handles_missing_external_id(): void
+    {
+        $payload = [
+            'source_system' => 'SAP',
+            'user'          => [
+                'name'  => 'Maria',
+                'email' => 'maria@empresa.com',
+            ],
+        ];
+
+        $dto = UserIntegrationDTO::fromArray($payload);
+
+        $this->assertNull($dto->user->externalId);
+    }
+
+    public function test_dto_is_readonly(): void
+    {
+        $dto = UserIntegrationDTO::fromArray($this->validPayload);
+
+        $this->expectException(\Error::class);
+        $dto->sourceSystem = 'OTHER'; // @phpstan-ignore-line
+    }
+}

--- a/tests/Unit/DTOs/Order/FinishOrderDTOTest.php
+++ b/tests/Unit/DTOs/Order/FinishOrderDTOTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\DTOs\Order;
+
+use App\DTOs\Order\FinishOrderDTO;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class FinishOrderDTOTest extends TestCase
+{
+    public function test_it_creates_dto_with_justification(): void
+    {
+        $dto = new FinishOrderDTO(justification: 'Pacote danificado no transporte.');
+
+        $this->assertSame('Pacote danificado no transporte.', $dto->justification);
+    }
+
+    public function test_it_creates_dto_with_null_justification(): void
+    {
+        $dto = new FinishOrderDTO();
+
+        $this->assertNull($dto->justification);
+    }
+
+    public function test_from_request_extracts_justification(): void
+    {
+        $request = Request::create('/finish', 'POST', ['justification' => 'Carga incompleta.']);
+
+        $dto = FinishOrderDTO::fromRequest($request);
+
+        $this->assertSame('Carga incompleta.', $dto->justification);
+    }
+
+    public function test_from_request_with_no_justification(): void
+    {
+        $request = Request::create('/finish', 'POST', []);
+
+        $dto = FinishOrderDTO::fromRequest($request);
+
+        $this->assertNull($dto->justification);
+    }
+
+    public function test_dto_is_readonly(): void
+    {
+        $dto = new FinishOrderDTO(justification: 'test');
+
+        $this->expectException(\Error::class);
+        $dto->justification = 'changed'; // @phpstan-ignore-line
+    }
+}

--- a/tests/Unit/DTOs/Order/ScheduleOrderDTOTest.php
+++ b/tests/Unit/DTOs/Order/ScheduleOrderDTOTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\DTOs\Order;
+
+use App\DTOs\Order\ScheduleOrderDTO;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ScheduleOrderDTOTest extends TestCase
+{
+    public function test_it_creates_dto_with_all_fields(): void
+    {
+        $dto = new ScheduleOrderDTO(
+            id: 'order-uuid-123',
+            scheduledAt: '2025-01-15 10:00:00',
+            status: 'scheduled',
+            dockId: 'dock-uuid-456',
+            operatorId: 'operator-uuid-789',
+        );
+
+        $this->assertSame('order-uuid-123', $dto->id);
+        $this->assertSame('2025-01-15 10:00:00', $dto->scheduledAt);
+        $this->assertSame('scheduled', $dto->status);
+        $this->assertSame('dock-uuid-456', $dto->dockId);
+        $this->assertSame('operator-uuid-789', $dto->operatorId);
+    }
+
+    public function test_it_creates_dto_with_optional_fields_null(): void
+    {
+        $dto = new ScheduleOrderDTO(
+            id: 'order-uuid-123',
+            scheduledAt: '2025-01-15 10:00:00',
+            status: 'scheduled',
+        );
+
+        $this->assertNull($dto->dockId);
+        $this->assertNull($dto->operatorId);
+    }
+
+    public function test_to_array_returns_correct_structure(): void
+    {
+        $dto = new ScheduleOrderDTO(
+            id: 'order-uuid-123',
+            scheduledAt: '2025-01-15 10:00:00',
+            status: 'scheduled',
+            dockId: 'dock-uuid',
+            operatorId: 'op-uuid',
+        );
+
+        $array = $dto->toArray();
+
+        $this->assertSame([
+            'id'           => 'order-uuid-123',
+            'scheduled_at' => '2025-01-15 10:00:00',
+            'status'       => 'scheduled',
+            'dock_id'      => 'dock-uuid',
+            'operator_id'  => 'op-uuid',
+        ], $array);
+    }
+
+    public function test_dto_is_readonly(): void
+    {
+        $dto = new ScheduleOrderDTO(
+            id: 'order-uuid-123',
+            scheduledAt: '2025-01-15 10:00:00',
+            status: 'scheduled',
+        );
+
+        $this->expectException(\Error::class);
+        $dto->id = 'new-id'; // @phpstan-ignore-line
+    }
+}


### PR DESCRIPTION
- Add Entity DTOs: CustomerDTO, DestinationDTO, CarrierDTO, VehicleDTO, DriverDTO, ProductDTO, UserDTO, DockDTO
- Add Integration DTOs: LoadingOrderIntegrationDTO, DockIntegrationDTO, UserIntegrationDTO, OrderItemIntegrationDTO, PackageIntegrationDTO
- Add Order DTOs: ScheduleOrderDTO, FinishOrderDTO
- Refactor EntityService to accept typed DTOs instead of plain arrays
- Refactor OrderService: scheduleOrder and finishOrder now receive DTOs
- Refactor LoadingOrderIntegrationService, DockService, UserService to accept integration DTOs
- Update OrderController to build DTOs from FormRequests
- Update ProcessLoadingOrderJob, ProcessDockJob, ProcessUserJob to build DTOs from serialized array payloads before delegating to services
- Add unit tests for all DTO classes (78 tests, 245 assertions passing)