### PR TITLE
fix: atualizando versão do php para 8.4 no Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.4-fpm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This pull request updates the PHP version used by our Docker image from 8.2 to 8.4 in the `Dockerfile`. This ensures that our application runs with the latest features and security updates from PHP. 

- Docker base image update:
  * Updated the `FROM` directive in `Dockerfile` to use `php:8.4-fpm` instead of `php:8.2-fpm`.